### PR TITLE
Add docker compose setup for local testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ include Makefile.vars.mk
 # Following includes do not print warnings or error if files aren't found
 # Optional Documentation module.
 -include docs/antora-preview.mk docs/antora-build.mk
+-include Makefile.compose.mk
 
 .PHONY: help
 help: ## Show this help
@@ -35,15 +36,12 @@ build-docker: build-bin ## Build docker image
 ensure-prometheus: .cache/prometheus ## Ensures that Prometheus is installed in the project dir. Downloads it if necessary.
 
 .PHONY: test
-test: export ACR_DB_URL = postgres://test-migrations:test-migrations@localhost:65432/test-migrations?sslmode=disable
-test: ensure-prometheus
-	docker rm -f test-migrations ||:
-	docker run -d --name test-migrations -e POSTGRES_DB=test-migrations -e POSTGRES_USER=test-migrations -e POSTGRES_PASSWORD=test-migrations -p65432:5432 postgres:13-bullseye
-	docker exec -t test-migrations sh -c 'until pg_isready; do sleep 1; done; sleep 1'
+test: export ACR_DB_URL = $(COMPOSE_DB_URL)
+test: ensure-prometheus docker-compose-down ping-postgres ## Run full test suite
 	go run github.com/appuio/appuio-cloud-reporting migrate
 	go run github.com/appuio/appuio-cloud-reporting migrate --seed
 	go test ./... -tags integration -coverprofile cover.out -covermode atomic
-	docker rm -f test-migrations
+	@$(COMPOSE_CMD) down
 
 .PHONY: fmt
 fmt: ## Run 'go fmt' against code
@@ -63,7 +61,7 @@ generate: ## Generate additional code and artifacts
 	@go generate ./...
 
 .PHONY: clean
-clean: ## Cleans local build artifacts
+clean: docker-compose-down ## Cleans local build artifacts
 	rm -rf docs/node_modules $(docs_out_dir) dist .cache
 
 .cache/prometheus:

--- a/Makefile
+++ b/Makefile
@@ -36,12 +36,14 @@ build-docker: build-bin ## Build docker image
 ensure-prometheus: .cache/prometheus ## Ensures that Prometheus is installed in the project dir. Downloads it if necessary.
 
 .PHONY: test
-test: export ACR_DB_URL = $(COMPOSE_DB_URL)
+test: export ACR_DB_URL = postgres://user:password@localhost:55432/db?sslmode=disable
+test: COMPOSE_FILE = docker-compose-test.yml
+test: compose_args = -p reporting-test
 test: ensure-prometheus docker-compose-down ping-postgres ## Run full test suite
 	go run github.com/appuio/appuio-cloud-reporting migrate
 	go run github.com/appuio/appuio-cloud-reporting migrate --seed
 	go test ./... -tags integration -coverprofile cover.out -covermode atomic
-	@$(COMPOSE_CMD) down
+	@$(COMPOSE_CMD) $(compose_args) down
 
 .PHONY: fmt
 fmt: ## Run 'go fmt' against code

--- a/Makefile.compose.mk
+++ b/Makefile.compose.mk
@@ -1,11 +1,11 @@
 .PHONY: docker-compose-up
 docker-compose-up: ## Starts up docker compose services
-	@$(COMPOSE_CMD) up --detach
+	@$(COMPOSE_CMD) -f $(COMPOSE_FILE) $(compose_args) up --detach
 
 .PHONY: docker-compose-down
 docker-compose-down: ## Stops docker compose services
-	@$(COMPOSE_CMD) down
+	@$(COMPOSE_CMD) -f $(COMPOSE_FILE) $(compose_args) down
 
 .PHONY: ping-postgres
 ping-postgres: docker-compose-up ## Waits until postgres is ready to accept connections
-	$(COMPOSE_CMD) exec -T -- postgres sh -c "until pg_isready; do sleep 1s; done"
+	$(COMPOSE_CMD) -f $(COMPOSE_FILE) $(compose_args) exec -T -- postgres sh -c "until pg_isready; do sleep 1s; done"

--- a/Makefile.compose.mk
+++ b/Makefile.compose.mk
@@ -8,4 +8,4 @@ docker-compose-down: ## Stops docker compose services
 
 .PHONY: ping-postgres
 ping-postgres: docker-compose-up ## Waits until postgres is ready to accept connections
-	$(COMPOSE_CMD) -f $(COMPOSE_FILE) $(compose_args) exec -T -- postgres sh -c "until pg_isready; do sleep 1s; done"
+	$(COMPOSE_CMD) -f $(COMPOSE_FILE) $(compose_args) exec -T -- postgres sh -c "until pg_isready; do sleep 1s; done; sleep 1s"

--- a/Makefile.compose.mk
+++ b/Makefile.compose.mk
@@ -1,0 +1,11 @@
+.PHONY: docker-compose-up
+docker-compose-up: ## Starts up docker compose services
+	@$(COMPOSE_CMD) up --detach
+
+.PHONY: docker-compose-down
+docker-compose-down: ## Stops docker compose services
+	@$(COMPOSE_CMD) down
+
+.PHONY: ping-postgres
+ping-postgres: docker-compose-up ## Waits until postgres is ready to accept connections
+	$(COMPOSE_CMD) exec -T -- postgres sh -c "until pg_isready; do sleep 1s; done"

--- a/Makefile.vars.mk
+++ b/Makefile.vars.mk
@@ -9,10 +9,14 @@ BIN_FILENAME ?= $(PROJECT_NAME)
 
 ## BUILD:docker
 DOCKER_CMD ?= docker
+COMPOSE_CMD ?= docker-compose
 
 IMG_TAG ?= latest
 # Image URL to use all building/pushing image targets
 CONTAINER_IMG ?= local.dev/$(PROJECT_OWNER)/$(PROJECT_NAME):$(IMG_TAG)
+
+## COMPOSE:
+COMPOSE_DB_URL = postgres://reporting:reporting@localhost:65432/reporting-db?sslmode=disable
 
 PROMETHEUS_VERSION ?= 2.32.1
 PROMETHEUS_DIST ?= $(shell go env GOOS)

--- a/Makefile.vars.mk
+++ b/Makefile.vars.mk
@@ -9,14 +9,15 @@ BIN_FILENAME ?= $(PROJECT_NAME)
 
 ## BUILD:docker
 DOCKER_CMD ?= docker
-COMPOSE_CMD ?= docker-compose
 
 IMG_TAG ?= latest
 # Image URL to use all building/pushing image targets
 CONTAINER_IMG ?= local.dev/$(PROJECT_OWNER)/$(PROJECT_NAME):$(IMG_TAG)
 
 ## COMPOSE:
-COMPOSE_DB_URL = postgres://reporting:reporting@localhost:65432/reporting-db?sslmode=disable
+COMPOSE_CMD ?= docker-compose
+COMPOSE_DB_URL ?= postgres://reporting:reporting@localhost:55432/reporting-db?sslmode=disable
+COMPOSE_FILE ?= docker-compose.yml
 
 PROMETHEUS_VERSION ?= 2.32.1
 PROMETHEUS_DIST ?= $(shell go env GOOS)

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ psql -U "${DB_USER}" -w -h localhost reporting
 ## Local Development
 
 Local development assumes a locally installed PostgreSQL database.
+This can be achieved by running `make docker-compose-up`.
+See `docker-compose.yml` for the configuration.
 
 ```sh
 createdb appuio-cloud-reporting-test

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -1,0 +1,11 @@
+# This file is used for unit tests
+version: "3.8"
+services:
+  postgres:
+    image: docker.io/library/postgres:13-bullseye
+    environment:
+      POSTGRES_DB: db
+      POSTGRES_PASSWORD: password
+      POSTGRES_USER: user
+    ports:
+      - "55432:5432"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+# This file can be used for local tinkering
 version: "3.8"
 services:
   postgres:
@@ -8,7 +9,7 @@ services:
       POSTGRES_USER: reporting
     ports:
       - "65432:5432"
-#     volumes:
-#       - "postgres:/var/lib/postgresql/data"
-# volumes:
-#   postgres: {}
+    volumes:
+      - "postgres:/var/lib/postgresql/data"
+volumes:
+  postgres: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3.8"
+services:
+  postgres:
+    image: docker.io/library/postgres:13-bullseye
+    environment:
+      POSTGRES_DB: reporting-db
+      POSTGRES_PASSWORD: reporting
+      POSTGRES_USER: reporting
+    ports:
+      - "65432:5432"
+#     volumes:
+#       - "postgres:/var/lib/postgresql/data"
+# volumes:
+#   postgres: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       POSTGRES_PASSWORD: reporting
       POSTGRES_USER: reporting
     ports:
-      - "65432:5432"
+      - "5432:5432"
     volumes:
       - "postgres:/var/lib/postgresql/data"
 volumes:


### PR DESCRIPTION
## Summary

* Adds docker-compose for easy test setup
* Requires that developers have `docker-compose` or Docker compose v2

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
