### PR TITLE
Fix PromQL join on persistent storage

### DIFF
--- a/pkg/db/seeds/appuio_cloud_persistent_storage.promql
+++ b/pkg/db/seeds/appuio_cloud_persistent_storage.promql
@@ -12,7 +12,7 @@ sum_over_time(
             kube_persistentvolume_capacity_bytes
             *
             # Join the PersistentVolumeClaim to get the namespace
-            on (persistentvolume)
+            on (cluster_id,persistentvolume)
             group_left(namespace, name)
             label_replace(
               kube_persistentvolume_claim_ref,
@@ -23,7 +23,7 @@ sum_over_time(
             )
             *
             # Join the PersistentVolume info to get StorageClass
-            on (persistentvolume)
+            on (cluster_id,persistentvolume)
             group_left(storageclass)
             # Do not differantiate between regular and encrypted storage class versions.
             label_replace(
@@ -35,7 +35,7 @@ sum_over_time(
             )
             *
             # Join the namespace label to get the tenant
-            on(namespace)
+            on(cluster_id,namespace)
             group_left(tenant_id)
             label_replace(
               kube_namespace_labels{label_appuio_io_organization=~".+"},


### PR DESCRIPTION
## Summary

Now that we have a second zone, the query fails due to labels not being
unique on a many-to-many time series join. Also join on `cluster_id`
resolves this.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
