### PR TITLE
Add subqueries for memory query

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/appuio/appuio-cloud-reporting
 
-go 1.17
+go 1.18
 
 require (
 	github.com/go-logr/logr v1.2.3

--- a/go.sum
+++ b/go.sum
@@ -32,7 +32,6 @@ cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RX
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/BurntSushi/toml v1.1.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
@@ -150,7 +149,6 @@ github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5m
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
-github.com/jackc/chunkreader v1.0.0 h1:4s39bBR8ByfqH+DKm8rQA3E1LHZWB9XWcrz8fqaZbe0=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=
 github.com/jackc/chunkreader/v2 v2.0.0/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=
 github.com/jackc/chunkreader/v2 v2.0.1 h1:i+RDz65UE+mmpjTfyz0MoVTnzeYxroil2G82ki7MGG8=
@@ -171,7 +169,6 @@ github.com/jackc/pgmock v0.0.0-20210724152146-4ad1a8207f65 h1:DadwsjnMwFjfWc9y5W
 github.com/jackc/pgmock v0.0.0-20210724152146-4ad1a8207f65/go.mod h1:5R2h2EEX+qri8jOWMbJCtaPWkrrNc7OHwsp2TCqp7ak=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
-github.com/jackc/pgproto3 v1.1.0 h1:FYYE4yRw+AgI8wXIinMlNjBbp/UitDJwfj5LqqewP1A=
 github.com/jackc/pgproto3 v1.1.0/go.mod h1:eR5FA3leWg7p9aeAqi37XOTgTIbkABlvcPB3E5rlc78=
 github.com/jackc/pgproto3/v2 v2.0.0-alpha1.0.20190420180111-c116219b62db/go.mod h1:bhq50y+xrl9n5mRYyCBFKkpRVTLYJVWeCc+mEAI3yXA=
 github.com/jackc/pgproto3/v2 v2.0.0-alpha1.0.20190609003834-432c2951c711/go.mod h1:uH0AWtUmuShn0bcesswc4aBTWGvw0cAxIJp+6OB//Wg=
@@ -412,7 +409,6 @@ golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f h1:oA4XRj0qtSt8Yo1Zms0CUlsT3KG69V2UGQWPBxujDmc=
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=

--- a/pkg/db/seeds/appuio_cloud_memory_sub_cpu.promql
+++ b/pkg/db/seeds/appuio_cloud_memory_sub_cpu.promql
@@ -11,10 +11,10 @@ sum_over_time(
         label_replace(
           clamp_min(
             (
-                sum by(cluster_id, namespace) (
+              sum by(cluster_id, namespace) (
                 # Get the CPU requests
                 kube_pod_container_resource_requests{resource="cpu"}
-                # Convert them to their memory equvalent by multiplying them by the memory to CPU ratio
+                # Convert them to their memory equivalent by multiplying them by the memory to CPU ratio
                 # Build that ratio from static values
                 * on(cluster_id) group_left()(
                   # Build a time series for Cloudscale LPG 2 (4096 MiB/core)

--- a/pkg/db/seeds/appuio_cloud_memory_sub_cpu.promql
+++ b/pkg/db/seeds/appuio_cloud_memory_sub_cpu.promql
@@ -1,0 +1,61 @@
+# Sum values over one hour.
+sum_over_time(
+  # Average over a one-minute time frame.
+  # NOTE: This is a sliding window. Results vary based on the queries' execution time.
+  avg_over_time(
+    # Add the final product label by joining the base product with the cluster ID, the tenant and the namespace.
+    label_join(
+      # Add the category label by joining the cluster ID and the namespace.
+      label_join(
+        # Add the base product identifier.
+        label_replace(
+          clamp_min(
+            (
+                sum by(cluster_id, namespace) (
+                # Get the CPU requests
+                kube_pod_container_resource_requests{resource="cpu"}
+                # Convert them to their memory equvalent by multiplying them by the memory to CPU ratio
+                # Build that ratio from static values
+                * on(cluster_id) group_left()(
+                  # Build a time series for Cloudscale LPG 2 (4096 MiB/core)
+                  label_replace(vector(4294967296), "cluster_id", "c-appuio-cloudscale-lpg-2", "", "")
+                  # Build a time series for Exoscale GVA-2 0 (5086 MiB/core)
+                  or label_replace(vector(5333057536), "cluster_id", "c-appuio-exoscale-ch-gva-2-0", "", "")
+                )
+              )
+              - sum by(cluster_id, namespace) (kube_pod_container_resource_requests{resource="memory"})
+            )
+            *
+            # Join namespace label `label_appuio_io_organization` as `tenant_id`.
+            on(cluster_id, namespace)
+            group_left(tenant_id)
+            label_replace(
+              kube_namespace_labels{label_appuio_io_organization=~".+"},
+              "tenant_id",
+              "$1",
+              "label_appuio_io_organization", "(.*)"
+            ),
+            # At least return 0
+            0
+          ),
+          "product",
+          "appuio_cloud_memory",
+          "product",
+          ".*"
+        ),
+        "category",
+        ":",
+        "cluster_id",
+        "namespace"
+      ),
+      "product",
+      ":",
+      "product",
+      "cluster_id",
+      "tenant_id",
+      "namespace"
+    )[45s:15s]
+  )[59m:1m]
+)
+# Convert to MiB
+/ 1024 / 1024

--- a/pkg/db/seeds/appuio_cloud_memory_sub_memory.promql
+++ b/pkg/db/seeds/appuio_cloud_memory_sub_memory.promql
@@ -10,9 +10,7 @@ sum_over_time(
         # Add the base product identifier.
         label_replace(
           clamp_min(
-            (
-              sum by(cluster_id, namespace) (kube_pod_container_resource_requests{resource="memory"})
-            )
+            sum by(cluster_id, namespace) (kube_pod_container_resource_requests{resource="memory"})
             *
             # Join namespace label `label_appuio_io_organization` as `tenant_id`.
             on(cluster_id, namespace)

--- a/pkg/db/seeds/appuio_cloud_memory_sub_memory.promql
+++ b/pkg/db/seeds/appuio_cloud_memory_sub_memory.promql
@@ -1,0 +1,49 @@
+# Sum values over one hour.
+sum_over_time(
+  # Average over a one-minute time frame.
+  # NOTE: This is a sliding window. Results vary based on the queries' execution time.
+  avg_over_time(
+    # Add the final product label by joining the base product with the cluster ID, the tenant and the namespace.
+    label_join(
+      # Add the category label by joining the cluster ID and the namespace.
+      label_join(
+        # Add the base product identifier.
+        label_replace(
+          clamp_min(
+            (
+              sum by(cluster_id, namespace) (kube_pod_container_resource_requests{resource="memory"})
+            )
+            *
+            # Join namespace label `label_appuio_io_organization` as `tenant_id`.
+            on(cluster_id, namespace)
+            group_left(tenant_id)
+            label_replace(
+              kube_namespace_labels{label_appuio_io_organization=~".+"},
+              "tenant_id",
+              "$1",
+              "label_appuio_io_organization", "(.*)"
+            ),
+            # At least return 128MiB
+            128 * 1024 * 1024
+          ),
+          "product",
+          "appuio_cloud_memory",
+          "product",
+          ".*"
+        ),
+        "category",
+        ":",
+        "cluster_id",
+        "namespace"
+      ),
+      "product",
+      ":",
+      "product",
+      "cluster_id",
+      "tenant_id",
+      "namespace"
+    )[45s:15s]
+  )[59m:1m]
+)
+# Convert to MiB
+/ 1024 / 1024

--- a/pkg/db/seeds_test.go
+++ b/pkg/db/seeds_test.go
@@ -24,23 +24,45 @@ func (s *SeedsTestSuite) TestSeedDefaultQueries() {
 
 	expQueryNum := 5
 
-	count := "SELECT ((SELECT COUNT(*) FROM queries) = $1)"
-	requireQueryTrue(t, d, count, 0)
+	count := "SELECT COUNT(*) FROM queries"
+	requireQueryEqual(t, d, 0, count)
+
+	require.NoError(t, db.SeedQueries(d.DB, []db.Query{
+		{
+			Name:        "appuio_cloud_memory",
+			Description: "Memory usage (maximum of requested and used memory) aggregated by namespace",
+			Unit:        "MiB",
+		},
+	}))
+	t.Log(t, count)
+	requireQueryEqual(t, d, 1, count)
+
+	// Some appuio_cloud_memory exists so don't create sub queries
 	err = db.Seed(d.DB)
 	require.NoError(t, err)
-	requireQueryTrue(t, d, count, expQueryNum)
+	requireQueryEqual(t, d, expQueryNum-2, count)
+
+	// Drop queries and check we create sub queries
+	_, err = d.DB.Exec("DELETE FROM queries;")
+	require.NoError(t, err)
 	err = db.Seed(d.DB)
 	require.NoError(t, err)
-	requireQueryTrue(t, d, count, expQueryNum)
+	requireQueryEqual(t, d, expQueryNum, count)
+	err = db.Seed(d.DB)
+	require.NoError(t, err)
+	requireQueryEqual(t, d, expQueryNum, count)
+}
+
+func requireQueryEqual[T any](t *testing.T, q sqlx.Queryer, expected T, query string, args ...interface{}) {
+	t.Helper()
+	var res T
+	require.NoError(t, sqlx.Get(q, &res, query, args...))
+	require.Equal(t, expected, res)
 }
 
 func requireQueryTrue(t *testing.T, q sqlx.Queryer, query string, args ...interface{}) {
 	t.Helper()
-
-	var result bool
-	err := sqlx.Get(q, &result, query, args...)
-	require.NoError(t, err)
-	require.True(t, result)
+	requireQueryEqual(t, q, true, query, args...)
 }
 
 func TestSeeds(t *testing.T) {

--- a/pkg/db/seeds_test.go
+++ b/pkg/db/seeds_test.go
@@ -22,14 +22,16 @@ func (s *SeedsTestSuite) TestSeedDefaultQueries() {
 	_, err := d.Exec("DELETE FROM queries")
 	require.NoError(t, err)
 
+	expQueryNum := 5
+
 	count := "SELECT ((SELECT COUNT(*) FROM queries) = $1)"
 	requireQueryTrue(t, d, count, 0)
 	err = db.Seed(d.DB)
 	require.NoError(t, err)
-	requireQueryTrue(t, d, count, len(db.DefaultQueries))
+	requireQueryTrue(t, d, count, expQueryNum)
 	err = db.Seed(d.DB)
 	require.NoError(t, err)
-	requireQueryTrue(t, d, count, len(db.DefaultQueries))
+	requireQueryTrue(t, d, count, expQueryNum)
 }
 
 func requireQueryTrue(t *testing.T, q sqlx.Queryer, query string, args ...interface{}) {

--- a/pkg/db/types.go
+++ b/pkg/db/types.go
@@ -18,6 +18,8 @@ type Query struct {
 	Unit        string
 
 	During pgtype.Tstzrange
+
+	subQueries []Query
 }
 
 // CreateQuery creates the given query


### PR DESCRIPTION
## Summary
Add default sub queries to seed. Tried not to be too smart with seeding as it quickly get's confusing. We only add the sub queries if we also add the main query.

The main query update is done in https://github.com/appuio/appuio-cloud-reporting/pull/46

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
