### PR TITLE
Do not expose DB IDs in the invoice

### DIFF
--- a/pkg/invoice/invoice.go
+++ b/pkg/invoice/invoice.go
@@ -86,7 +86,6 @@ type Tenant struct {
 
 // ProductRef represents a product reference in the invoice.
 type ProductRef struct {
-	ID     string `db:"product_ref_id"`
 	Source string `db:"product_ref_source"`
 	Target string `db:"product_ref_target"`
 }
@@ -161,6 +160,8 @@ type rawItem struct {
 	ParentQueryID sql.NullString `db:"parent_query_id"`
 	// DiscountID is the id of the corresponding discount
 	DiscountID string `db:"discount_id"`
+	// ProductID is the id of the corresponding product entry
+	ProductID string `db:"product_ref_id"`
 }
 
 func itemsForCategory(ctx context.Context, tx *sqlx.Tx, tenant db.Tenant, category db.Category, year int, month time.Month) ([]Item, error) {
@@ -199,13 +200,13 @@ func buildItemHierarchy(items []rawItem) []Item {
 	for _, item := range items {
 		if !item.ParentQueryID.Valid {
 			// These three IDs uniquely identify the line item
-			itemID := fmt.Sprintf("%s:%s:%s", item.QueryID, item.ProductRef.ID, item.DiscountID)
+			itemID := fmt.Sprintf("%s:%s:%s", item.QueryID, item.ProductID, item.DiscountID)
 			mainItems[itemID] = item.Item
 		}
 	}
 	for _, item := range items {
 		if item.ParentQueryID.Valid {
-			pqid := fmt.Sprintf("%s:%s:%s", item.ParentQueryID.String, item.ProductRef.ID, item.DiscountID)
+			pqid := fmt.Sprintf("%s:%s:%s", item.ParentQueryID.String, item.ProductID, item.DiscountID)
 			parent, ok := mainItems[pqid]
 			if ok {
 				parent.SubItems = append(parent.SubItems, SubItem{

--- a/pkg/invoice/invoice.go
+++ b/pkg/invoice/invoice.go
@@ -25,7 +25,6 @@ type Invoice struct {
 
 // Category represents a category of the invoice i.e. a namespace.
 type Category struct {
-	ID     string
 	Source string
 	Target string
 	Items  []Item
@@ -79,7 +78,6 @@ type SubItem struct {
 
 // Tenant represents a tenant in the invoice.
 type Tenant struct {
-	ID     string
 	Source string
 	Target string
 }
@@ -133,7 +131,6 @@ func invoiceForTenant(ctx context.Context, tx *sqlx.Tx, tenant db.Tenant, year i
 			return Invoice{}, err
 		}
 		invCategories = append(invCategories, Category{
-			ID:     category.Id,
 			Source: category.Source,
 			Target: category.Target.String,
 			Items:  items,
@@ -142,7 +139,7 @@ func invoiceForTenant(ctx context.Context, tx *sqlx.Tx, tenant db.Tenant, year i
 	}
 
 	return Invoice{
-		Tenant:      Tenant{ID: tenant.Id, Source: tenant.Source, Target: tenant.Target.String},
+		Tenant:      Tenant{Source: tenant.Source, Target: tenant.Target.String},
 		PeriodStart: time.Date(year, month, 1, 0, 0, 0, 0, time.UTC),
 		PeriodEnd:   time.Date(year, month, 1, 0, 0, 0, 0, time.UTC).AddDate(0, 1, -1),
 		Categories:  invCategories,

--- a/pkg/invoice/invoice_test.go
+++ b/pkg/invoice/invoice_test.go
@@ -294,7 +294,6 @@ func (s *InvoiceSuite) TestInvoice_Generate() {
 
 		invoiceEqual(t, invoice.Invoice{
 			Tenant: invoice.Tenant{
-				ID:     s.tricellTenant.Id,
 				Source: s.tricellTenant.Source,
 				Target: s.tricellTenant.Target.String,
 			},
@@ -302,7 +301,6 @@ func (s *InvoiceSuite) TestInvoice_Generate() {
 			PeriodEnd:   time.Date(2021, time.December, 31, 0, 0, 0, 0, time.UTC),
 			Categories: []invoice.Category{
 				{
-					ID:     s.uroborosCategory.Id,
 					Source: s.uroborosCategory.Source,
 					Target: s.uroborosCategory.Target.String,
 					Items: []invoice.Item{
@@ -377,7 +375,6 @@ func (s *InvoiceSuite) TestInvoice_Generate() {
 
 		invoiceEqual(t, invoice.Invoice{
 			Tenant: invoice.Tenant{
-				ID:     s.umbrellaCorpTenant.Id,
 				Source: s.umbrellaCorpTenant.Source,
 				Target: s.umbrellaCorpTenant.Target.String,
 			},
@@ -385,7 +382,6 @@ func (s *InvoiceSuite) TestInvoice_Generate() {
 			PeriodEnd:   time.Date(2021, time.December, 31, 0, 0, 0, 0, time.UTC),
 			Categories: []invoice.Category{
 				{
-					ID:     s.p12aCategory.Id,
 					Source: s.p12aCategory.Source,
 					Target: s.p12aCategory.Target.String,
 					Items: []invoice.Item{
@@ -441,7 +437,6 @@ func (s *InvoiceSuite) TestInvoice_Generate() {
 					Total: memP12Total + storP12Total,
 				},
 				{
-					ID:     s.nestElevCtrlCategory.Id,
 					Source: s.nestElevCtrlCategory.Source,
 					Target: s.nestElevCtrlCategory.Target.String,
 					Items: []invoice.Item{
@@ -490,7 +485,11 @@ func invoiceEqual(t *testing.T, expInv, inv invoice.Invoice) bool {
 
 func sortInvoice(inv *invoice.Invoice) {
 	sort.Slice(inv.Categories, func(i, j int) bool {
-		return inv.Categories[i].ID < inv.Categories[j].ID
+		// This is horrible, but I don't really have any ID or similar to sort on..
+		iraw, _ := json.Marshal(inv.Categories[i])
+		jraw, _ := json.Marshal(inv.Categories[j])
+		return string(iraw) < string(jraw)
+
 	})
 	for catIter := range inv.Categories {
 		sort.Slice(inv.Categories[catIter].Items, func(i, j int) bool {

--- a/pkg/invoice/invoice_test.go
+++ b/pkg/invoice/invoice_test.go
@@ -309,7 +309,6 @@ func (s *InvoiceSuite) TestInvoice_Generate() {
 						{
 							Description: s.memoryQuery.Description,
 							ProductRef: invoice.ProductRef{
-								ID:     s.memoryProduct.Id,
 								Source: s.memoryProduct.Source,
 								Target: s.memoryProduct.Target.String,
 							},
@@ -335,7 +334,6 @@ func (s *InvoiceSuite) TestInvoice_Generate() {
 						{
 							Description: s.memoryQuery.Description,
 							ProductRef: invoice.ProductRef{
-								ID:     s.memoryProduct.Id,
 								Source: s.memoryProduct.Source,
 								Target: s.memoryProduct.Target.String,
 							},
@@ -394,7 +392,6 @@ func (s *InvoiceSuite) TestInvoice_Generate() {
 						{
 							Description: s.storageQuery.Description,
 							ProductRef: invoice.ProductRef{
-								ID:     s.storageProduct.Id,
 								Source: s.storageProduct.Source,
 								Target: s.storageProduct.Target.String,
 							},
@@ -410,7 +407,6 @@ func (s *InvoiceSuite) TestInvoice_Generate() {
 						{
 							Description: s.memoryQuery.Description,
 							ProductRef: invoice.ProductRef{
-								ID:     s.memoryProduct.Id,
 								Source: s.memoryProduct.Source,
 								Target: s.memoryProduct.Target.String,
 							},
@@ -452,7 +448,6 @@ func (s *InvoiceSuite) TestInvoice_Generate() {
 						{
 							Description: s.memoryQuery.Description,
 							ProductRef: invoice.ProductRef{
-								ID:     s.memoryProduct.Id,
 								Source: s.memoryProduct.Source,
 								Target: s.memoryProduct.Target.String,
 							},


### PR DESCRIPTION
The database IDs are internal and should never be exposed. Also exposing the IDs in invoices makes testing needlessly complicated, as the ID changes with every run.


Very strictly speaking this is a breaking change, but I seriously hope we never used this ID


## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
