### PR TITLE
Expose the query name for every invoice line item

### DIFF
--- a/pkg/invoice/invoice.go
+++ b/pkg/invoice/invoice.go
@@ -37,7 +37,7 @@ type Item struct {
 	// Description describes the line item.
 	Description string
 	// QueryName is the name of the query that generated this line item
-	QueryName string `db:"query_name"`
+	QueryName string
 	// Product describes the product this item is based on.
 	ProductRef
 	// Quantity represents the amount of the resource used.
@@ -67,7 +67,7 @@ type SubItem struct {
 	// Description describes the line item.
 	Description string
 	// QueryName is the name of the query that generated this line item
-	QueryName string `db:"query_name"`
+	QueryName string
 	// Quantity represents the amount of the resource used.
 	Quantity float64
 	// QuantityMin represents the minimum amount of the resource used.
@@ -169,7 +169,7 @@ func itemsForCategory(ctx context.Context, tx *sqlx.Tx, tenant db.Tenant, catego
 	var items []rawItem
 	err := sqlx.SelectContext(ctx, tx, &items,
 		`SELECT  queries.id as query_id, queries.parent_id as parent_query_id, discounts.id as discount_id,
-				queries.description, queries.name as query_name,
+				queries.description, queries.name as queryName,
 				SUM(facts.quantity) as quantity, MIN(facts.quantity) as quantitymin, AVG(facts.quantity) as quantityavg, MAX(facts.quantity) as quantitymax,
 				queries.unit, products.amount AS pricePerUnit, discounts.discount,
 				products.id as product_ref_id, products.source as product_ref_source, COALESCE(products.target,''::text) as product_ref_target,

--- a/pkg/invoice/invoice_test.go
+++ b/pkg/invoice/invoice_test.go
@@ -303,6 +303,7 @@ func (s *InvoiceSuite) TestInvoice_Generate() {
 					Items: []invoice.Item{
 						{
 							Description: s.memoryQuery.Description,
+							QueryName:   s.memoryQuery.Name,
 							ProductRef: invoice.ProductRef{
 								Source: s.memoryProduct.Source,
 								Target: s.memoryProduct.Target.String,
@@ -318,6 +319,7 @@ func (s *InvoiceSuite) TestInvoice_Generate() {
 							SubItems: []invoice.SubItem{
 								{
 									Description: s.memorySubQuery.Description,
+									QueryName:   s.memorySubQuery.Name,
 									Quantity:    subMemQuantity,
 									QuantityMin: subMemQuantity,
 									QuantityAvg: subMemQuantity,
@@ -328,6 +330,7 @@ func (s *InvoiceSuite) TestInvoice_Generate() {
 						},
 						{
 							Description: s.memoryQuery.Description,
+							QueryName:   s.memoryQuery.Name,
 							ProductRef: invoice.ProductRef{
 								Source: s.memoryProduct.Source,
 								Target: s.memoryProduct.Target.String,
@@ -343,6 +346,7 @@ func (s *InvoiceSuite) TestInvoice_Generate() {
 							SubItems: []invoice.SubItem{
 								{
 									Description: s.memorySubQuery.Description,
+									QueryName:   s.memorySubQuery.Name,
 									Quantity:    subMemQuantity,
 									QuantityMin: subMemQuantity,
 									QuantityAvg: subMemQuantity,
@@ -384,6 +388,7 @@ func (s *InvoiceSuite) TestInvoice_Generate() {
 					Items: []invoice.Item{
 						{
 							Description: s.storageQuery.Description,
+							QueryName:   s.storageQuery.Name,
 							ProductRef: invoice.ProductRef{
 								Source: s.storageProduct.Source,
 								Target: s.storageProduct.Target.String,
@@ -399,6 +404,7 @@ func (s *InvoiceSuite) TestInvoice_Generate() {
 						},
 						{
 							Description: s.memoryQuery.Description,
+							QueryName:   s.memoryQuery.Name,
 							ProductRef: invoice.ProductRef{
 								Source: s.memoryProduct.Source,
 								Target: s.memoryProduct.Target.String,
@@ -414,6 +420,7 @@ func (s *InvoiceSuite) TestInvoice_Generate() {
 							SubItems: []invoice.SubItem{
 								{
 									Description: s.memorySubQuery.Description,
+									QueryName:   s.memorySubQuery.Name,
 									Quantity:    subMemP12Quantity * stampsInTimerange,
 									QuantityMin: subMemP12Quantity,
 									QuantityAvg: subMemP12Quantity,
@@ -422,6 +429,7 @@ func (s *InvoiceSuite) TestInvoice_Generate() {
 								},
 								{
 									Description: s.memoryOtherSubQuery.Description,
+									QueryName:   s.memoryOtherSubQuery.Name,
 									Quantity:    otherSubMemP12Quantity * stampsInTimerange,
 									QuantityMin: otherSubMemP12Quantity,
 									QuantityAvg: otherSubMemP12Quantity,
@@ -439,6 +447,7 @@ func (s *InvoiceSuite) TestInvoice_Generate() {
 					Items: []invoice.Item{
 						{
 							Description: s.memoryQuery.Description,
+							QueryName:   s.memoryQuery.Name,
 							ProductRef: invoice.ProductRef{
 								Source: s.memoryProduct.Source,
 								Target: s.memoryProduct.Target.String,

--- a/pkg/invoice/testdata/discounts.json
+++ b/pkg/invoice/testdata/discounts.json
@@ -13,6 +13,7 @@
 				"Items": [
 					{
 						"Description": "test description",
+						"QueryName": "test",
 						"Source": "my-product",
 						"Target": "",
 						"Quantity": 9072,
@@ -26,6 +27,7 @@
 						"SubItems": [
 							{
 								"Description": "A sub query of Test",
+								"QueryName": "sub-test",
 								"Quantity": 864,
 								"QuantityMin": 4,
 								"QuantityAvg": 4,
@@ -43,6 +45,7 @@
 				"Items": [
 					{
 						"Description": "test description",
+						"QueryName": "test",
 						"Source": "my-product",
 						"Target": "",
 						"Quantity": 9072,
@@ -56,6 +59,7 @@
 						"SubItems": [
 							{
 								"Description": "A sub query of Test",
+								"QueryName": "sub-test",
 								"Quantity": 864,
 								"QuantityMin": 4,
 								"QuantityAvg": 4,
@@ -73,6 +77,7 @@
 				"Items": [
 					{
 						"Description": "test description",
+						"QueryName": "test",
 						"Source": "my-product",
 						"Target": "",
 						"Quantity": 9072,
@@ -86,6 +91,7 @@
 						"SubItems": [
 							{
 								"Description": "A sub query of Test",
+								"QueryName": "sub-test",
 								"Quantity": 864,
 								"QuantityMin": 4,
 								"QuantityAvg": 4,
@@ -114,6 +120,7 @@
 				"Items": [
 					{
 						"Description": "test description",
+						"QueryName": "test",
 						"Source": "my-product",
 						"Target": "",
 						"Quantity": 4968,
@@ -127,6 +134,7 @@
 						"SubItems": [
 							{
 								"Description": "A sub query of Test",
+								"QueryName": "sub-test",
 								"Quantity": 432,
 								"QuantityMin": 2,
 								"QuantityAvg": 2,

--- a/pkg/invoice/testdata/products.json
+++ b/pkg/invoice/testdata/products.json
@@ -13,6 +13,7 @@
 				"Items": [
 					{
 						"Description": "test description",
+						"QueryName": "test",
 						"Source": "my-product:my-cluster:my-tenant",
 						"Target": "",
 						"Quantity": 9072,
@@ -26,6 +27,7 @@
 						"SubItems": [
 							{
 								"Description": "A sub query of Test",
+								"QueryName": "sub-test",
 								"Quantity": 864,
 								"QuantityMin": 4,
 								"QuantityAvg": 4,
@@ -43,6 +45,7 @@
 				"Items": [
 					{
 						"Description": "test description",
+						"QueryName": "test",
 						"Source": "my-product:my-cluster:my-tenant",
 						"Target": "",
 						"Quantity": 9072,
@@ -56,6 +59,7 @@
 						"SubItems": [
 							{
 								"Description": "A sub query of Test",
+								"QueryName": "sub-test",
 								"Quantity": 864,
 								"QuantityMin": 4,
 								"QuantityAvg": 4,
@@ -73,6 +77,7 @@
 				"Items": [
 					{
 						"Description": "test description",
+						"QueryName": "test",
 						"Source": "my-product:*:my-tenant",
 						"Target": "",
 						"Quantity": 9072,
@@ -86,6 +91,7 @@
 						"SubItems": [
 							{
 								"Description": "A sub query of Test",
+								"QueryName": "sub-test",
 								"Quantity": 864,
 								"QuantityMin": 4,
 								"QuantityAvg": 4,
@@ -114,6 +120,7 @@
 				"Items": [
 					{
 						"Description": "test description",
+						"QueryName": "test",
 						"Source": "my-product",
 						"Target": "",
 						"Quantity": 4968,
@@ -127,6 +134,7 @@
 						"SubItems": [
 							{
 								"Description": "A sub query of Test",
+								"QueryName": "sub-test",
 								"Quantity": 432,
 								"QuantityMin": 2,
 								"QuantityAvg": 2,

--- a/pkg/invoice/testdata/simple.json
+++ b/pkg/invoice/testdata/simple.json
@@ -13,6 +13,7 @@
 				"Items": [
 					{
 						"Description": "test description",
+						"QueryName": "test",
 						"Source": "my-product",
 						"Target": "",
 						"Quantity": 9072,
@@ -26,6 +27,7 @@
 						"SubItems": [
 							{
 								"Description": "A sub query of Test",
+								"QueryName": "sub-test",
 								"Quantity": 864,
 								"QuantityMin": 4,
 								"QuantityAvg": 4,
@@ -34,6 +36,7 @@
 							},
 							{
 								"Description": "An other sub query of Test",
+								"QueryName": "sub-test2",
 								"Quantity": 1512,
 								"QuantityMin": 7,
 								"QuantityAvg": 7,
@@ -62,6 +65,7 @@
 				"Items": [
 					{
 						"Description": "test description",
+						"QueryName": "test",
 						"Source": "my-product",
 						"Target": "",
 						"Quantity": 4968,
@@ -75,6 +79,7 @@
 						"SubItems": [
 							{
 								"Description": "A sub query of Test",
+								"QueryName": "sub-test",
 								"Quantity": 432,
 								"QuantityMin": 2,
 								"QuantityAvg": 2,
@@ -83,6 +88,7 @@
 							},
 							{
 								"Description": "An other sub query of Test",
+								"QueryName": "sub-test2",
 								"Quantity": 0,
 								"QuantityMin": 0,
 								"QuantityAvg": 0,

--- a/pkg/invoice/testdata/timed_discounts.json
+++ b/pkg/invoice/testdata/timed_discounts.json
@@ -13,6 +13,7 @@
 				"Items": [
 					{
 						"Description": "test description",
+						"QueryName": "test",
 						"Source": "my-product",
 						"Target": "",
 						"Quantity": 1008,
@@ -26,6 +27,7 @@
 						"SubItems": [
 							{
 								"Description": "A sub query of Test",
+								"QueryName": "sub-test",
 								"Quantity": 96,
 								"QuantityMin": 4,
 								"QuantityAvg": 4,
@@ -36,6 +38,7 @@
 					},
 					{
 						"Description": "test description",
+						"QueryName": "test",
 						"Source": "my-product",
 						"Target": "",
 						"Quantity": 2016,
@@ -49,6 +52,7 @@
 						"SubItems": [
 							{
 								"Description": "A sub query of Test",
+								"QueryName": "sub-test",
 								"Quantity": 192,
 								"QuantityMin": 4,
 								"QuantityAvg": 4,
@@ -59,6 +63,7 @@
 					},
 					{
 						"Description": "test description",
+						"QueryName": "test",
 						"Source": "my-product",
 						"Target": "",
 						"Quantity": 6048,
@@ -72,6 +77,7 @@
 						"SubItems": [
 							{
 								"Description": "A sub query of Test",
+								"QueryName": "sub-test",
 								"Quantity": 576,
 								"QuantityMin": 4,
 								"QuantityAvg": 4,
@@ -89,6 +95,7 @@
 				"Items": [
 					{
 						"Description": "test description",
+						"QueryName": "test",
 						"Source": "my-product",
 						"Target": "",
 						"Quantity": 1008,
@@ -102,6 +109,7 @@
 						"SubItems": [
 							{
 								"Description": "A sub query of Test",
+								"QueryName": "sub-test",
 								"Quantity": 96,
 								"QuantityMin": 4,
 								"QuantityAvg": 4,
@@ -112,6 +120,7 @@
 					},
 					{
 						"Description": "test description",
+						"QueryName": "test",
 						"Source": "my-product",
 						"Target": "",
 						"Quantity": 2016,
@@ -125,6 +134,7 @@
 						"SubItems": [
 							{
 								"Description": "A sub query of Test",
+								"QueryName": "sub-test",
 								"Quantity": 192,
 								"QuantityMin": 4,
 								"QuantityAvg": 4,
@@ -135,6 +145,7 @@
 					},
 					{
 						"Description": "test description",
+						"QueryName": "test",
 						"Source": "my-product",
 						"Target": "",
 						"Quantity": 6048,
@@ -148,6 +159,7 @@
 						"SubItems": [
 							{
 								"Description": "A sub query of Test",
+								"QueryName": "sub-test",
 								"Quantity": 576,
 								"QuantityMin": 4,
 								"QuantityAvg": 4,
@@ -165,6 +177,7 @@
 				"Items": [
 					{
 						"Description": "test description",
+						"QueryName": "test",
 						"Source": "my-product",
 						"Target": "",
 						"Quantity": 1008,
@@ -178,6 +191,7 @@
 						"SubItems": [
 							{
 								"Description": "A sub query of Test",
+								"QueryName": "sub-test",
 								"Quantity": 96,
 								"QuantityMin": 4,
 								"QuantityAvg": 4,
@@ -188,6 +202,7 @@
 					},
 					{
 						"Description": "test description",
+						"QueryName": "test",
 						"Source": "my-product",
 						"Target": "",
 						"Quantity": 2016,
@@ -201,6 +216,7 @@
 						"SubItems": [
 							{
 								"Description": "A sub query of Test",
+								"QueryName": "sub-test",
 								"Quantity": 192,
 								"QuantityMin": 4,
 								"QuantityAvg": 4,
@@ -211,6 +227,7 @@
 					},
 					{
 						"Description": "test description",
+						"QueryName": "test",
 						"Source": "my-product",
 						"Target": "",
 						"Quantity": 6048,
@@ -224,6 +241,7 @@
 						"SubItems": [
 							{
 								"Description": "A sub query of Test",
+								"QueryName": "sub-test",
 								"Quantity": 576,
 								"QuantityMin": 4,
 								"QuantityAvg": 4,
@@ -252,6 +270,7 @@
 				"Items": [
 					{
 						"Description": "test description",
+						"QueryName": "test",
 						"Source": "my-product",
 						"Target": "",
 						"Quantity": 1104,
@@ -265,6 +284,7 @@
 						"SubItems": [
 							{
 								"Description": "A sub query of Test",
+								"QueryName": "sub-test",
 								"Quantity": 96,
 								"QuantityMin": 2,
 								"QuantityAvg": 2,
@@ -275,6 +295,7 @@
 					},
 					{
 						"Description": "test description",
+						"QueryName": "test",
 						"Source": "my-product",
 						"Target": "",
 						"Quantity": 3312,
@@ -288,6 +309,7 @@
 						"SubItems": [
 							{
 								"Description": "A sub query of Test",
+								"QueryName": "sub-test",
 								"Quantity": 288,
 								"QuantityMin": 2,
 								"QuantityAvg": 2,
@@ -298,6 +320,7 @@
 					},
 					{
 						"Description": "test description",
+						"QueryName": "test",
 						"Source": "my-product",
 						"Target": "",
 						"Quantity": 552,
@@ -311,6 +334,7 @@
 						"SubItems": [
 							{
 								"Description": "A sub query of Test",
+								"QueryName": "sub-test",
 								"Quantity": 48,
 								"QuantityMin": 2,
 								"QuantityAvg": 2,

--- a/pkg/invoice/testdata/timed_query.json
+++ b/pkg/invoice/testdata/timed_query.json
@@ -13,6 +13,7 @@
 				"Items": [
 					{
 						"Description": "new nicer query",
+						"QueryName": "test",
 						"Source": "my-product",
 						"Target": "",
 						"Quantity": 8280,
@@ -26,6 +27,7 @@
 						"SubItems": [
 							{
 								"Description": "A better sub query of Test",
+								"QueryName": "new-sub-test",
 								"Quantity": 480,
 								"QuantityMin": 4,
 								"QuantityAvg": 4,
@@ -36,6 +38,7 @@
 					},
 					{
 						"Description": "test description",
+						"QueryName": "test",
 						"Source": "my-product",
 						"Target": "",
 						"Quantity": 4032,
@@ -49,6 +52,7 @@
 						"SubItems": [
 							{
 								"Description": "A sub query of Test",
+								"QueryName": "sub-test",
 								"Quantity": 384,
 								"QuantityMin": 4,
 								"QuantityAvg": 4,
@@ -57,6 +61,7 @@
 							},
 							{
 								"Description": "An other sub query of Test that stops early",
+								"QueryName": "sub-test2",
 								"Quantity": 168,
 								"QuantityMin": 7,
 								"QuantityAvg": 7,
@@ -85,6 +90,7 @@
 				"Items": [
 					{
 						"Description": "new nicer query",
+						"QueryName": "test",
 						"Source": "my-product",
 						"Target": "",
 						"Quantity": 8280,
@@ -98,6 +104,7 @@
 						"SubItems": [
 							{
 								"Description": "A better sub query of Test",
+								"QueryName": "new-sub-test",
 								"Quantity": 240,
 								"QuantityMin": 2,
 								"QuantityAvg": 2,
@@ -108,6 +115,7 @@
 					},
 					{
 						"Description": "test description",
+						"QueryName": "test",
 						"Source": "my-product",
 						"Target": "",
 						"Quantity": 2208,
@@ -121,6 +129,7 @@
 						"SubItems": [
 							{
 								"Description": "A sub query of Test",
+								"QueryName": "sub-test",
 								"Quantity": 192,
 								"QuantityMin": 2,
 								"QuantityAvg": 2,
@@ -129,6 +138,7 @@
 							},
 							{
 								"Description": "An other sub query of Test that stops early",
+								"QueryName": "sub-test2",
 								"Quantity": 0,
 								"QuantityMin": 0,
 								"QuantityAvg": 0,


### PR DESCRIPTION
By returning the query names for line items, ERP adapters can detect the source of a line item and handle the invoice rendering accordingly. This can for example be helpful for sub-items.

We may or may not need this for the Odoo adapter, but I don't see a reason to hide this information

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
