### PR TITLE
Return subitems in invoices as a map

### DIFF
--- a/pkg/invoice/invoice_test.go
+++ b/pkg/invoice/invoice_test.go
@@ -316,8 +316,8 @@ func (s *InvoiceSuite) TestInvoice_Generate() {
 							PricePerUnit: s.memoryProduct.Amount,
 							Discount:     s.memoryDiscount.Discount,
 							Total:        quantity * s.memoryProduct.Amount,
-							SubItems: []invoice.SubItem{
-								{
+							SubItems: map[string]invoice.SubItem{
+								s.memorySubQuery.Name: {
 									Description: s.memorySubQuery.Description,
 									QueryName:   s.memorySubQuery.Name,
 									Quantity:    subMemQuantity,
@@ -343,8 +343,8 @@ func (s *InvoiceSuite) TestInvoice_Generate() {
 							PricePerUnit: s.memoryProduct.Amount,
 							Discount:     s.tricellMemoryDiscount.Discount,
 							Total:        quantity * s.memoryProduct.Amount * 0.5,
-							SubItems: []invoice.SubItem{
-								{
+							SubItems: map[string]invoice.SubItem{
+								s.memorySubQuery.Name: {
 									Description: s.memorySubQuery.Description,
 									QueryName:   s.memorySubQuery.Name,
 									Quantity:    subMemQuantity,
@@ -401,6 +401,7 @@ func (s *InvoiceSuite) TestInvoice_Generate() {
 							PricePerUnit: s.storageProduct.Amount,
 							Discount:     s.storageDiscount.Discount,
 							Total:        storP12Total,
+							SubItems:     map[string]invoice.SubItem{},
 						},
 						{
 							Description: s.memoryQuery.Description,
@@ -417,8 +418,8 @@ func (s *InvoiceSuite) TestInvoice_Generate() {
 							PricePerUnit: s.memoryProduct.Amount,
 							Discount:     s.memoryDiscount.Discount,
 							Total:        memP12Total,
-							SubItems: []invoice.SubItem{
-								{
+							SubItems: map[string]invoice.SubItem{
+								s.memorySubQuery.Name: {
 									Description: s.memorySubQuery.Description,
 									QueryName:   s.memorySubQuery.Name,
 									Quantity:    subMemP12Quantity * stampsInTimerange,
@@ -427,7 +428,7 @@ func (s *InvoiceSuite) TestInvoice_Generate() {
 									QuantityMax: subMemP12Quantity,
 									Unit:        s.memorySubQuery.Unit,
 								},
-								{
+								s.memoryOtherSubQuery.Name: {
 									Description: s.memoryOtherSubQuery.Description,
 									QueryName:   s.memoryOtherSubQuery.Name,
 									Quantity:    otherSubMemP12Quantity * stampsInTimerange,
@@ -460,6 +461,7 @@ func (s *InvoiceSuite) TestInvoice_Generate() {
 							PricePerUnit: s.memoryProduct.Amount,
 							Discount:     s.memoryDiscount.Discount,
 							Total:        memNestTotal,
+							SubItems:     map[string]invoice.SubItem{},
 						},
 					},
 					Total: memNestTotal,

--- a/pkg/invoice/main_test.go
+++ b/pkg/invoice/main_test.go
@@ -50,10 +50,5 @@ func sortInvoice(inv *invoice.Invoice) {
 			jraw, _ := json.Marshal(inv.Categories[catIter].Items[j])
 			return string(iraw) < string(jraw)
 		})
-		for itemIter := range inv.Categories[catIter].Items {
-			sort.Slice(inv.Categories[catIter].Items[itemIter].SubItems, func(i, j int) bool {
-				return inv.Categories[catIter].Items[itemIter].SubItems[i].Description < inv.Categories[catIter].Items[itemIter].SubItems[j].Description
-			})
-		}
 	}
 }

--- a/pkg/invoice/testdata/discounts.json
+++ b/pkg/invoice/testdata/discounts.json
@@ -24,8 +24,8 @@
 						"PricePerUnit": 1,
 						"Discount": 0.5,
 						"Total": 4536,
-						"SubItems": [
-							{
+						"SubItems": {
+							"sub-test": {
 								"Description": "A sub query of Test",
 								"QueryName": "sub-test",
 								"Quantity": 864,
@@ -34,7 +34,7 @@
 								"QuantityMax": 4,
 								"Unit": "tps"
 							}
-						]
+						}
 					}
 				],
 				"Total": 4536
@@ -56,8 +56,8 @@
 						"PricePerUnit": 1,
 						"Discount": 0.5,
 						"Total": 4536,
-						"SubItems": [
-							{
+						"SubItems": {
+							"sub-test": {
 								"Description": "A sub query of Test",
 								"QueryName": "sub-test",
 								"Quantity": 864,
@@ -66,7 +66,7 @@
 								"QuantityMax": 4,
 								"Unit": "tps"
 							}
-						]
+						}
 					}
 				],
 				"Total": 4536
@@ -88,8 +88,8 @@
 						"PricePerUnit": 1,
 						"Discount": 0.25,
 						"Total": 6804,
-						"SubItems": [
-							{
+						"SubItems": {
+							"sub-test": {
 								"Description": "A sub query of Test",
 								"QueryName": "sub-test",
 								"Quantity": 864,
@@ -98,7 +98,7 @@
 								"QuantityMax": 4,
 								"Unit": "tps"
 							}
-						]
+						}
 					}
 				],
 				"Total": 6804
@@ -131,8 +131,8 @@
 						"PricePerUnit": 1,
 						"Discount": 0,
 						"Total": 4968,
-						"SubItems": [
-							{
+						"SubItems": {
+							"sub-test": {
 								"Description": "A sub query of Test",
 								"QueryName": "sub-test",
 								"Quantity": 432,
@@ -141,7 +141,7 @@
 								"QuantityMax": 2,
 								"Unit": "tps"
 							}
-						]
+						}
 					}
 				],
 				"Total": 4968

--- a/pkg/invoice/testdata/products.json
+++ b/pkg/invoice/testdata/products.json
@@ -24,8 +24,8 @@
 						"PricePerUnit": 3,
 						"Discount": 0,
 						"Total": 27216,
-						"SubItems": [
-							{
+						"SubItems": {
+							"sub-test": {
 								"Description": "A sub query of Test",
 								"QueryName": "sub-test",
 								"Quantity": 864,
@@ -34,7 +34,7 @@
 								"QuantityMax": 4,
 								"Unit": "tps"
 							}
-						]
+						}
 					}
 				],
 				"Total": 27216
@@ -56,8 +56,8 @@
 						"PricePerUnit": 3,
 						"Discount": 0,
 						"Total": 27216,
-						"SubItems": [
-							{
+						"SubItems": {
+							"sub-test": {
 								"Description": "A sub query of Test",
 								"QueryName": "sub-test",
 								"Quantity": 864,
@@ -66,7 +66,7 @@
 								"QuantityMax": 4,
 								"Unit": "tps"
 							}
-						]
+						}
 					}
 				],
 				"Total": 27216
@@ -88,8 +88,8 @@
 						"PricePerUnit": 2,
 						"Discount": 0,
 						"Total": 18144,
-						"SubItems": [
-							{
+						"SubItems": {
+							"sub-test": {
 								"Description": "A sub query of Test",
 								"QueryName": "sub-test",
 								"Quantity": 864,
@@ -98,7 +98,7 @@
 								"QuantityMax": 4,
 								"Unit": "tps"
 							}
-						]
+						}
 					}
 				],
 				"Total": 18144
@@ -131,8 +131,8 @@
 						"PricePerUnit": 1,
 						"Discount": 0,
 						"Total": 4968,
-						"SubItems": [
-							{
+						"SubItems": {
+							"sub-test": {
 								"Description": "A sub query of Test",
 								"QueryName": "sub-test",
 								"Quantity": 432,
@@ -141,7 +141,7 @@
 								"QuantityMax": 2,
 								"Unit": "tps"
 							}
-						]
+						}
 					}
 				],
 				"Total": 4968

--- a/pkg/invoice/testdata/simple.json
+++ b/pkg/invoice/testdata/simple.json
@@ -24,8 +24,8 @@
 						"PricePerUnit": 1,
 						"Discount": 0,
 						"Total": 9072,
-						"SubItems": [
-							{
+						"SubItems": {
+							"sub-test": {
 								"Description": "A sub query of Test",
 								"QueryName": "sub-test",
 								"Quantity": 864,
@@ -34,7 +34,7 @@
 								"QuantityMax": 4,
 								"Unit": "tps"
 							},
-							{
+							"sub-test2": {
 								"Description": "An other sub query of Test",
 								"QueryName": "sub-test2",
 								"Quantity": 1512,
@@ -43,7 +43,7 @@
 								"QuantityMax": 7,
 								"Unit": "tps"
 							}
-						]
+						}
 					}
 				],
 				"Total": 9072
@@ -76,8 +76,8 @@
 						"PricePerUnit": 1,
 						"Discount": 0,
 						"Total": 4968,
-						"SubItems": [
-							{
+						"SubItems": {
+							"sub-test": {
 								"Description": "A sub query of Test",
 								"QueryName": "sub-test",
 								"Quantity": 432,
@@ -86,7 +86,7 @@
 								"QuantityMax": 2,
 								"Unit": "tps"
 							},
-							{
+							"sub-test2": {
 								"Description": "An other sub query of Test",
 								"QueryName": "sub-test2",
 								"Quantity": 0,
@@ -95,7 +95,7 @@
 								"QuantityMax": 0,
 								"Unit": "tps"
 							}
-						]
+						}
 					}
 				],
 				"Total": 4968

--- a/pkg/invoice/testdata/timed_discounts.json
+++ b/pkg/invoice/testdata/timed_discounts.json
@@ -24,8 +24,8 @@
 						"PricePerUnit": 1,
 						"Discount": 0.5,
 						"Total": 504,
-						"SubItems": [
-							{
+						"SubItems": {
+							"sub-test": {
 								"Description": "A sub query of Test",
 								"QueryName": "sub-test",
 								"Quantity": 96,
@@ -34,7 +34,7 @@
 								"QuantityMax": 4,
 								"Unit": "tps"
 							}
-						]
+						}
 					},
 					{
 						"Description": "test description",
@@ -49,8 +49,8 @@
 						"PricePerUnit": 1,
 						"Discount": 0.25,
 						"Total": 1512,
-						"SubItems": [
-							{
+						"SubItems": {
+							"sub-test": {
 								"Description": "A sub query of Test",
 								"QueryName": "sub-test",
 								"Quantity": 192,
@@ -59,7 +59,7 @@
 								"QuantityMax": 4,
 								"Unit": "tps"
 							}
-						]
+						}
 					},
 					{
 						"Description": "test description",
@@ -74,8 +74,8 @@
 						"PricePerUnit": 1,
 						"Discount": 0,
 						"Total": 6048,
-						"SubItems": [
-							{
+						"SubItems": {
+							"sub-test": {
 								"Description": "A sub query of Test",
 								"QueryName": "sub-test",
 								"Quantity": 576,
@@ -84,7 +84,7 @@
 								"QuantityMax": 4,
 								"Unit": "tps"
 							}
-						]
+						}
 					}
 				],
 				"Total": 8064
@@ -106,8 +106,8 @@
 						"PricePerUnit": 1,
 						"Discount": 0.5,
 						"Total": 504,
-						"SubItems": [
-							{
+						"SubItems": {
+							"sub-test": {
 								"Description": "A sub query of Test",
 								"QueryName": "sub-test",
 								"Quantity": 96,
@@ -116,7 +116,7 @@
 								"QuantityMax": 4,
 								"Unit": "tps"
 							}
-						]
+						}
 					},
 					{
 						"Description": "test description",
@@ -131,8 +131,8 @@
 						"PricePerUnit": 1,
 						"Discount": 0.25,
 						"Total": 1512,
-						"SubItems": [
-							{
+						"SubItems": {
+							"sub-test": {
 								"Description": "A sub query of Test",
 								"QueryName": "sub-test",
 								"Quantity": 192,
@@ -141,7 +141,7 @@
 								"QuantityMax": 4,
 								"Unit": "tps"
 							}
-						]
+						}
 					},
 					{
 						"Description": "test description",
@@ -156,8 +156,8 @@
 						"PricePerUnit": 1,
 						"Discount": 0,
 						"Total": 6048,
-						"SubItems": [
-							{
+						"SubItems": {
+							"sub-test": {
 								"Description": "A sub query of Test",
 								"QueryName": "sub-test",
 								"Quantity": 576,
@@ -166,7 +166,7 @@
 								"QuantityMax": 4,
 								"Unit": "tps"
 							}
-						]
+						}
 					}
 				],
 				"Total": 8064
@@ -188,8 +188,8 @@
 						"PricePerUnit": 1,
 						"Discount": 0.5,
 						"Total": 504,
-						"SubItems": [
-							{
+						"SubItems": {
+							"sub-test": {
 								"Description": "A sub query of Test",
 								"QueryName": "sub-test",
 								"Quantity": 96,
@@ -198,7 +198,7 @@
 								"QuantityMax": 4,
 								"Unit": "tps"
 							}
-						]
+						}
 					},
 					{
 						"Description": "test description",
@@ -213,8 +213,8 @@
 						"PricePerUnit": 1,
 						"Discount": 0.25,
 						"Total": 1512,
-						"SubItems": [
-							{
+						"SubItems": {
+							"sub-test": {
 								"Description": "A sub query of Test",
 								"QueryName": "sub-test",
 								"Quantity": 192,
@@ -223,7 +223,7 @@
 								"QuantityMax": 4,
 								"Unit": "tps"
 							}
-						]
+						}
 					},
 					{
 						"Description": "test description",
@@ -238,8 +238,8 @@
 						"PricePerUnit": 1,
 						"Discount": 0,
 						"Total": 6048,
-						"SubItems": [
-							{
+						"SubItems": {
+							"sub-test": {
 								"Description": "A sub query of Test",
 								"QueryName": "sub-test",
 								"Quantity": 576,
@@ -248,7 +248,7 @@
 								"QuantityMax": 4,
 								"Unit": "tps"
 							}
-						]
+						}
 					}
 				],
 				"Total": 8064
@@ -281,8 +281,8 @@
 						"PricePerUnit": 1,
 						"Discount": 0.25,
 						"Total": 828,
-						"SubItems": [
-							{
+						"SubItems": {
+							"sub-test": {
 								"Description": "A sub query of Test",
 								"QueryName": "sub-test",
 								"Quantity": 96,
@@ -291,7 +291,7 @@
 								"QuantityMax": 2,
 								"Unit": "tps"
 							}
-						]
+						}
 					},
 					{
 						"Description": "test description",
@@ -306,8 +306,8 @@
 						"PricePerUnit": 1,
 						"Discount": 0,
 						"Total": 3312,
-						"SubItems": [
-							{
+						"SubItems": {
+							"sub-test": {
 								"Description": "A sub query of Test",
 								"QueryName": "sub-test",
 								"Quantity": 288,
@@ -316,7 +316,7 @@
 								"QuantityMax": 2,
 								"Unit": "tps"
 							}
-						]
+						}
 					},
 					{
 						"Description": "test description",
@@ -331,8 +331,8 @@
 						"PricePerUnit": 1,
 						"Discount": 0.5,
 						"Total": 276,
-						"SubItems": [
-							{
+						"SubItems": {
+							"sub-test": {
 								"Description": "A sub query of Test",
 								"QueryName": "sub-test",
 								"Quantity": 48,
@@ -341,7 +341,7 @@
 								"QuantityMax": 2,
 								"Unit": "tps"
 							}
-						]
+						}
 					}
 				],
 				"Total": 4416

--- a/pkg/invoice/testdata/timed_query.json
+++ b/pkg/invoice/testdata/timed_query.json
@@ -24,8 +24,8 @@
 						"PricePerUnit": 1,
 						"Discount": 0,
 						"Total": 8280,
-						"SubItems": [
-							{
+						"SubItems": {
+							"new-sub-test": {
 								"Description": "A better sub query of Test",
 								"QueryName": "new-sub-test",
 								"Quantity": 480,
@@ -34,7 +34,7 @@
 								"QuantityMax": 4,
 								"Unit": "tps"
 							}
-						]
+						}
 					},
 					{
 						"Description": "test description",
@@ -49,8 +49,8 @@
 						"PricePerUnit": 1,
 						"Discount": 0,
 						"Total": 4032,
-						"SubItems": [
-							{
+						"SubItems": {
+							"sub-test": {
 								"Description": "A sub query of Test",
 								"QueryName": "sub-test",
 								"Quantity": 384,
@@ -59,7 +59,7 @@
 								"QuantityMax": 4,
 								"Unit": "tps"
 							},
-							{
+							"sub-test2": {
 								"Description": "An other sub query of Test that stops early",
 								"QueryName": "sub-test2",
 								"Quantity": 168,
@@ -68,7 +68,7 @@
 								"QuantityMax": 7,
 								"Unit": "tps"
 							}
-						]
+						}
 					}
 				],
 				"Total": 12312
@@ -101,8 +101,8 @@
 						"PricePerUnit": 1,
 						"Discount": 0,
 						"Total": 8280,
-						"SubItems": [
-							{
+						"SubItems": {
+							"new-sub-test": {
 								"Description": "A better sub query of Test",
 								"QueryName": "new-sub-test",
 								"Quantity": 240,
@@ -111,7 +111,7 @@
 								"QuantityMax": 2,
 								"Unit": "tps"
 							}
-						]
+						}
 					},
 					{
 						"Description": "test description",
@@ -126,8 +126,8 @@
 						"PricePerUnit": 1,
 						"Discount": 0,
 						"Total": 2208,
-						"SubItems": [
-							{
+						"SubItems": {
+							"sub-test": {
 								"Description": "A sub query of Test",
 								"QueryName": "sub-test",
 								"Quantity": 192,
@@ -136,7 +136,7 @@
 								"QuantityMax": 2,
 								"Unit": "tps"
 							},
-							{
+							"sub-test2": {
 								"Description": "An other sub query of Test that stops early",
 								"QueryName": "sub-test2",
 								"Quantity": 0,
@@ -145,7 +145,7 @@
 								"QuantityMax": 0,
 								"Unit": "tps"
 							}
-						]
+						}
 					}
 				],
 				"Total": 10488


### PR DESCRIPTION
In https://github.com/appuio/appuio-cloud-reporting/pull/65 it was suggested to switch to a map for subitems in invoices.

This is technically a breaking change, but as we did not have a release since introducing subitems we can ignore this

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
