### PR TITLE
Only count CPU and memory requests of running pods

### DIFF
--- a/pkg/db/seeds/appuio_cloud_memory.promql
+++ b/pkg/db/seeds/appuio_cloud_memory.promql
@@ -19,21 +19,21 @@ sum_over_time(
                   sum by(cluster_id, namespace) (container_memory_working_set_bytes{image!=""})
                   # IMPORTANT: one clause must use equal. If used grater and lesser than, equal values will be dropped.
                   >=
-                  sum by(cluster_id, namespace) (kube_pod_container_resource_requests{resource="memory"})
+                  sum by(cluster_id, namespace) (kube_pod_container_resource_requests{resource="memory"}*on(cluster_id,pod,namespace) group_left kube_pod_status_phase{phase="Running"})
                 )
                 or
                 # Select reserved memory if higher.
                 (
                   sum by(cluster_id, namespace) (container_memory_working_set_bytes{image!=""})
                   <
-                  sum by(cluster_id, namespace) (kube_pod_container_resource_requests{resource="memory"})
+                  sum by(cluster_id, namespace) (kube_pod_container_resource_requests{resource="memory"}*on(cluster_id,pod,namespace) group_left kube_pod_status_phase{phase="Running"})
                 )
               )
               # Add CPU requests in violation to the ratio provided by the platform.
               + clamp_min(
                   # Convert CPU request to their memory equivalent.
                   sum by(cluster_id, namespace) (
-                    kube_pod_container_resource_requests{resource="cpu"}
+                    kube_pod_container_resource_requests{resource="cpu"}*on(cluster_id,pod,namespace) group_left kube_pod_status_phase{phase="Running"}
                     # Build that ratio from static values
                     * on(cluster_id) group_left()(
                       # Build a time series of ratio for Cloudscale LPG 2 (4096 MiB/core)
@@ -43,7 +43,7 @@ sum_over_time(
                     )
                   )
                   # Subtract memory request
-                  - sum by(cluster_id, namespace) (kube_pod_container_resource_requests{resource="memory"}
+                  - sum by(cluster_id, namespace) (kube_pod_container_resource_requests{resource="memory"}*on(cluster_id,pod,namespace) group_left kube_pod_status_phase{phase="Running"}
               # Only values above zero are in violation.
               ), 0)
             )

--- a/pkg/db/seeds/appuio_cloud_memory.promql
+++ b/pkg/db/seeds/appuio_cloud_memory.promql
@@ -19,14 +19,14 @@ sum_over_time(
                   sum by(cluster_id, namespace) (container_memory_working_set_bytes{image!=""})
                   # IMPORTANT: one clause must use equal. If used grater and lesser than, equal values will be dropped.
                   >=
-                  sum by(cluster_id, namespace) (kube_pod_container_resource_requests{resource="memory"}*on(cluster_id,pod,namespace) group_left kube_pod_status_phase{phase="Running"})
+                  sum by(cluster_id, namespace) (kube_pod_container_resource_requests{resource="memory"} * on(cluster_id,pod,namespace) group_left kube_pod_status_phase{phase="Running"})
                 )
                 or
                 # Select reserved memory if higher.
                 (
                   sum by(cluster_id, namespace) (container_memory_working_set_bytes{image!=""})
                   <
-                  sum by(cluster_id, namespace) (kube_pod_container_resource_requests{resource="memory"}*on(cluster_id,pod,namespace) group_left kube_pod_status_phase{phase="Running"})
+                  sum by(cluster_id, namespace) (kube_pod_container_resource_requests{resource="memory"} * on(cluster_id,pod,namespace) group_left kube_pod_status_phase{phase="Running"})
                 )
               )
               # Add CPU requests in violation to the ratio provided by the platform.
@@ -43,7 +43,7 @@ sum_over_time(
                     )
                   )
                   # Subtract memory request
-                  - sum by(cluster_id, namespace) (kube_pod_container_resource_requests{resource="memory"}*on(cluster_id,pod,namespace) group_left kube_pod_status_phase{phase="Running"}
+                  - sum by(cluster_id, namespace) (kube_pod_container_resource_requests{resource="memory"} * on(cluster_id,pod,namespace) group_left kube_pod_status_phase{phase="Running"}
               # Only values above zero are in violation.
               ), 0)
             )

--- a/pkg/db/seeds/appuio_cloud_memory_sub_cpu.promql
+++ b/pkg/db/seeds/appuio_cloud_memory_sub_cpu.promql
@@ -13,7 +13,7 @@ sum_over_time(
             (
               sum by(cluster_id, namespace) (
                 # Get the CPU requests
-                kube_pod_container_resource_requests{resource="cpu"}*on(cluster_id,pod,namespace) group_left kube_pod_status_phase{phase="Running"}
+                kube_pod_container_resource_requests{resource="cpu"} * on(cluster_id,pod,namespace) group_left kube_pod_status_phase{phase="Running"}
                 # Convert them to their memory equivalent by multiplying them by the memory to CPU ratio
                 # Build that ratio from static values
                 * on(cluster_id) group_left()(
@@ -23,7 +23,7 @@ sum_over_time(
                   or label_replace(vector(5333057536), "cluster_id", "c-appuio-exoscale-ch-gva-2-0", "", "")
                 )
               )
-              - sum by(cluster_id, namespace) (kube_pod_container_resource_requests{resource="memory"}*on(cluster_id,pod,namespace) group_left kube_pod_status_phase{phase="Running"})
+              - sum by(cluster_id, namespace) (kube_pod_container_resource_requests{resource="memory"} * on(cluster_id,pod,namespace) group_left kube_pod_status_phase{phase="Running"})
             )
             *
             # Join namespace label `label_appuio_io_organization` as `tenant_id`.

--- a/pkg/db/seeds/appuio_cloud_memory_sub_cpu.promql
+++ b/pkg/db/seeds/appuio_cloud_memory_sub_cpu.promql
@@ -13,7 +13,7 @@ sum_over_time(
             (
               sum by(cluster_id, namespace) (
                 # Get the CPU requests
-                kube_pod_container_resource_requests{resource="cpu"}
+                kube_pod_container_resource_requests{resource="cpu"}*on(cluster_id,pod,namespace) group_left kube_pod_status_phase{phase="Running"}
                 # Convert them to their memory equivalent by multiplying them by the memory to CPU ratio
                 # Build that ratio from static values
                 * on(cluster_id) group_left()(
@@ -23,7 +23,7 @@ sum_over_time(
                   or label_replace(vector(5333057536), "cluster_id", "c-appuio-exoscale-ch-gva-2-0", "", "")
                 )
               )
-              - sum by(cluster_id, namespace) (kube_pod_container_resource_requests{resource="memory"})
+              - sum by(cluster_id, namespace) (kube_pod_container_resource_requests{resource="memory"}*on(cluster_id,pod,namespace) group_left kube_pod_status_phase{phase="Running"})
             )
             *
             # Join namespace label `label_appuio_io_organization` as `tenant_id`.

--- a/pkg/db/seeds/appuio_cloud_memory_sub_memory.promql
+++ b/pkg/db/seeds/appuio_cloud_memory_sub_memory.promql
@@ -10,7 +10,7 @@ sum_over_time(
         # Add the base product identifier.
         label_replace(
           clamp_min(
-            sum by(cluster_id, namespace) (kube_pod_container_resource_requests{resource="memory"}*on(cluster_id,pod,namespace) group_left kube_pod_status_phase{phase="Running"})
+            sum by(cluster_id, namespace) (kube_pod_container_resource_requests{resource="memory"} * on(cluster_id,pod,namespace) group_left kube_pod_status_phase{phase="Running"})
             *
             # Join namespace label `label_appuio_io_organization` as `tenant_id`.
             on(cluster_id, namespace)

--- a/pkg/db/seeds/appuio_cloud_memory_sub_memory.promql
+++ b/pkg/db/seeds/appuio_cloud_memory_sub_memory.promql
@@ -10,7 +10,7 @@ sum_over_time(
         # Add the base product identifier.
         label_replace(
           clamp_min(
-            sum by(cluster_id, namespace) (kube_pod_container_resource_requests{resource="memory"})
+            sum by(cluster_id, namespace) (kube_pod_container_resource_requests{resource="memory"}*on(cluster_id,pod,namespace) group_left kube_pod_status_phase{phase="Running"})
             *
             # Join namespace label `label_appuio_io_organization` as `tenant_id`.
             on(cluster_id, namespace)


### PR DESCRIPTION
Right now we also count requests for terminated pods. We should not do
this.

This query will take effect on 2022-05-06 00:00:00


## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
