### PR TITLE
Fix max of (reserved, used) memory

### DIFF
--- a/pkg/db/seeds/appuio_cloud_memory.promql
+++ b/pkg/db/seeds/appuio_cloud_memory.promql
@@ -24,6 +24,7 @@ sum_over_time(
                 or
                 # Select reserved memory if higher.
                 (
+                  # IMPORTANT: The desired time series must always be first.
                   sum by(cluster_id, namespace) (kube_pod_container_resource_requests{resource="memory"} * on(cluster_id,pod,namespace) group_left kube_pod_status_phase{phase="Running"})
                   >
                   sum by(cluster_id, namespace) (container_memory_working_set_bytes{image!=""})


### PR DESCRIPTION
Prometheus returns the first value if the condition is true. No value otherwise.

With the old query we always selected the working_set value since it was the first value in both equations.

Switching the values around to have both in the first position should fix this query.

Old: `vector(1) >= vector(3) or vector(1) < vector(3) == 1`
New: `vector(1) >= vector(3) or vector(3) > vector(1) == 3`

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
