### PR TITLE
Fix query error caused by force-replaced pod

### DIFF
--- a/pkg/db/seeds/appuio_cloud_memory.promql
+++ b/pkg/db/seeds/appuio_cloud_memory.promql
@@ -19,13 +19,13 @@ sum_over_time(
                   sum by(cluster_id, namespace) (container_memory_working_set_bytes{image!=""})
                   # IMPORTANT: one clause must use equal. If used grater and lesser than, equal values will be dropped.
                   >=
-                  sum by(cluster_id, namespace) (kube_pod_container_resource_requests{resource="memory"} * on(cluster_id,pod,namespace) group_left kube_pod_status_phase{phase="Running"})
+                  sum by(cluster_id, namespace) (kube_pod_container_resource_requests{resource="memory"} * on(uid) group_left kube_pod_status_phase{phase="Running"})
                 )
                 or
                 # Select reserved memory if higher.
                 (
                   # IMPORTANT: The desired time series must always be first.
-                  sum by(cluster_id, namespace) (kube_pod_container_resource_requests{resource="memory"} * on(cluster_id,pod,namespace) group_left kube_pod_status_phase{phase="Running"})
+                  sum by(cluster_id, namespace) (kube_pod_container_resource_requests{resource="memory"} * on(uid) group_left kube_pod_status_phase{phase="Running"})
                   >
                   sum by(cluster_id, namespace) (container_memory_working_set_bytes{image!=""})
                 )
@@ -34,7 +34,7 @@ sum_over_time(
               + clamp_min(
                   # Convert CPU request to their memory equivalent.
                   sum by(cluster_id, namespace) (
-                    kube_pod_container_resource_requests{resource="cpu"}*on(cluster_id,pod,namespace) group_left kube_pod_status_phase{phase="Running"}
+                    kube_pod_container_resource_requests{resource="cpu"} * on(uid) group_left kube_pod_status_phase{phase="Running"}
                     # Build that ratio from static values
                     * on(cluster_id) group_left()(
                       # Build a time series of ratio for Cloudscale LPG 2 (4096 MiB/core)
@@ -44,7 +44,7 @@ sum_over_time(
                     )
                   )
                   # Subtract memory request
-                  - sum by(cluster_id, namespace) (kube_pod_container_resource_requests{resource="memory"} * on(cluster_id,pod,namespace) group_left kube_pod_status_phase{phase="Running"}
+                  - sum by(cluster_id, namespace) (kube_pod_container_resource_requests{resource="memory"} * on(uid) group_left kube_pod_status_phase{phase="Running"}
               # Only values above zero are in violation.
               ), 0)
             )

--- a/pkg/db/seeds/appuio_cloud_memory_sub_cpu.promql
+++ b/pkg/db/seeds/appuio_cloud_memory_sub_cpu.promql
@@ -13,7 +13,7 @@ sum_over_time(
             (
               sum by(cluster_id, namespace) (
                 # Get the CPU requests
-                kube_pod_container_resource_requests{resource="cpu"} * on(cluster_id,pod,namespace) group_left kube_pod_status_phase{phase="Running"}
+                kube_pod_container_resource_requests{resource="cpu"} * on(uid) group_left kube_pod_status_phase{phase="Running"}
                 # Convert them to their memory equivalent by multiplying them by the memory to CPU ratio
                 # Build that ratio from static values
                 * on(cluster_id) group_left()(
@@ -23,7 +23,7 @@ sum_over_time(
                   or label_replace(vector(5333057536), "cluster_id", "c-appuio-exoscale-ch-gva-2-0", "", "")
                 )
               )
-              - sum by(cluster_id, namespace) (kube_pod_container_resource_requests{resource="memory"} * on(cluster_id,pod,namespace) group_left kube_pod_status_phase{phase="Running"})
+              - sum by(cluster_id, namespace) (kube_pod_container_resource_requests{resource="memory"} * on(uid) group_left kube_pod_status_phase{phase="Running"})
             )
             *
             # Join namespace label `label_appuio_io_organization` as `tenant_id`.

--- a/pkg/db/seeds/appuio_cloud_memory_sub_memory.promql
+++ b/pkg/db/seeds/appuio_cloud_memory_sub_memory.promql
@@ -12,7 +12,7 @@ sum_over_time(
           clamp_min(
             (
               clamp_min(
-                sum by(cluster_id, namespace) (kube_pod_container_resource_requests{resource="memory"} * on(cluster_id,pod,namespace) group_left kube_pod_status_phase{phase="Running"}),
+                sum by(cluster_id, namespace) (kube_pod_container_resource_requests{resource="memory"} * on(uid) group_left kube_pod_status_phase{phase="Running"}),
                 128 * 1024 * 1024
               )
               - sum by(cluster_id, namespace) (container_memory_working_set_bytes{image!=""})


### PR DESCRIPTION
When force-replacing a pod, two pods with the same name, but differing `uid` label, can exist for a short time in the time series.

![image](https://user-images.githubusercontent.com/1249775/178286732-1ec4c49a-8ea7-41a8-9331-7fed6c694474.png)

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
