### PR TITLE
Abort request if data is missing (not all Thanos stores are available)

### DIFF
--- a/pkg/thanos/thanos.go
+++ b/pkg/thanos/thanos.go
@@ -1,16 +1,20 @@
 package thanos
 
-import "net/http"
+import (
+	"net/http"
+	"strconv"
+)
 
-// NoPartialResponseRoundTripper adds a new RoundTripper to the chain that sets the partial_response query parameter to false.
-type NoPartialResponseRoundTripper struct {
+// PartialResponseRoundTripper adds a new RoundTripper to the chain that sets the partial_response query parameter to the value of Allow.
+type PartialResponseRoundTripper struct {
 	http.RoundTripper
+	Allow bool
 }
 
 // RoundTrip implements the RoundTripper interface.
-func (t *NoPartialResponseRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+func (t *PartialResponseRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	q := req.URL.Query()
-	q.Set("partial_response", "false")
+	q.Set("partial_response", strconv.FormatBool(t.Allow))
 	req.URL.RawQuery = q.Encode()
 	return t.RoundTripper.RoundTrip(req)
 }

--- a/pkg/thanos/thanos.go
+++ b/pkg/thanos/thanos.go
@@ -1,0 +1,16 @@
+package thanos
+
+import "net/http"
+
+// NoPartialResponseRoundTripper adds a new RoundTripper to the chain that sets the partial_response query parameter to false.
+type NoPartialResponseRoundTripper struct {
+	http.RoundTripper
+}
+
+// RoundTrip implements the RoundTripper interface.
+func (t *NoPartialResponseRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	q := req.URL.Query()
+	q.Set("partial_response", "false")
+	req.URL.RawQuery = q.Encode()
+	return t.RoundTripper.RoundTrip(req)
+}

--- a/pkg/thanos/thanos_test.go
+++ b/pkg/thanos/thanos_test.go
@@ -1,0 +1,26 @@
+package thanos
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNoPartialResponseRoundTripper(t *testing.T) {
+	rt := NoPartialResponseRoundTripper{roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		require.Regexp(t, `partial_response=false`, r.URL.RawQuery)
+		return nil, errors.New("not implemented")
+	})}
+
+	_, _ = rt.RoundTrip(httptest.NewRequest("GET", "https://thanos.io", nil))
+	_, _ = rt.RoundTrip(httptest.NewRequest("GET", "https://thanos.io?testly=blub", nil))
+}
+
+type roundTripFunc func(r *http.Request) (*http.Response, error)
+
+func (s roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return s(r)
+}

--- a/pkg/thanos/thanos_test.go
+++ b/pkg/thanos/thanos_test.go
@@ -2,21 +2,55 @@ package thanos
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-func TestNoPartialResponseRoundTripper(t *testing.T) {
-	rt := NoPartialResponseRoundTripper{roundTripFunc(func(r *http.Request) (*http.Response, error) {
-		require.Regexp(t, `partial_response=false`, r.URL.RawQuery)
-		return nil, errors.New("not implemented")
-	})}
+func TestPartialResponseRoundTripper_X(t *testing.T) {
+	testCases := []struct {
+		url   string
+		allow bool
+	}{
+		{
+			url:   "https://thanos.io",
+			allow: false,
+		},
+		{
+			url:   "https://thanos.io?testly=blub",
+			allow: false,
+		},
+		{
+			url:   "https://thanos.io",
+			allow: true,
+		},
+		{
+			url:   "https://thanos.io?testly=blub",
+			allow: true,
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(fmt.Sprintf("allow %v, url %s", tC.allow, tC.url), func(t *testing.T) {
+			origUrl, err := url.Parse(tC.url)
+			require.NoError(t, err)
 
-	_, _ = rt.RoundTrip(httptest.NewRequest("GET", "https://thanos.io", nil))
-	_, _ = rt.RoundTrip(httptest.NewRequest("GET", "https://thanos.io?testly=blub", nil))
+			rt := PartialResponseRoundTripper{
+				RoundTripper: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+					require.Contains(t, r.URL.RawQuery, `partial_response=`+strconv.FormatBool(tC.allow))
+					require.Contains(t, r.URL.RawQuery, origUrl.RawQuery)
+					return nil, errors.New("not implemented")
+				}),
+				Allow: tC.allow,
+			}
+
+			_, _ = rt.RoundTrip(httptest.NewRequest("GET", tC.url, nil))
+		})
+	}
 }
 
 type roundTripFunc func(r *http.Request) (*http.Response, error)

--- a/report_command.go
+++ b/report_command.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/appuio/appuio-cloud-reporting/pkg/db"
 	"github.com/appuio/appuio-cloud-reporting/pkg/report"
+	"github.com/appuio/appuio-cloud-reporting/pkg/thanos"
 	"github.com/jmoiron/sqlx"
 	"github.com/prometheus/client_golang/api"
 	apiv1 "github.com/prometheus/client_golang/api/prometheus/v1"
@@ -125,7 +126,8 @@ func (cmd *reportCommand) runReport(ctx context.Context, db *sqlx.DB, promClient
 
 func newPrometheusAPIClient(promURL string) (apiv1.API, error) {
 	client, err := api.NewClient(api.Config{
-		Address: promURL,
+		Address:      promURL,
+		RoundTripper: &thanos.NoPartialResponseRoundTripper{RoundTripper: api.DefaultRoundTripper},
 	})
 	return apiv1.NewAPI(client), err
 }


### PR DESCRIPTION
We got missing data and did not see it. The default is just returning data that can be queried.

https://thanos.io/v0.28/components/query.md/#partial-response-strategy

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
