### PR TITLE
Add node label as class for compute queries

### DIFF
--- a/pkg/db/seeds/appuio_cloud_memory.promql
+++ b/pkg/db/seeds/appuio_cloud_memory.promql
@@ -16,25 +16,25 @@ sum_over_time(
               (
                 # Select used memory if higher.
                 (
-                  sum by(cluster_id, namespace, label_kubernetes_io_arch) (container_memory_working_set_bytes{image!=""} * on(node) group_left(label_kubernetes_io_arch) kube_node_labels)
+                  sum by(cluster_id, namespace, label_appuio_io_node_class) (container_memory_working_set_bytes{image!=""} * on(node) group_left(label_appuio_io_node_class) kube_node_labels)
                   # IMPORTANT: one clause must use equal. If used grater and lesser than, equal values will be dropped.
                   >=
-                  sum by(cluster_id, namespace, label_kubernetes_io_arch) (kube_pod_container_resource_requests{resource="memory"} * on(uid, cluster_id, pod, namespace) group_left kube_pod_status_phase{phase="Running"} * on(node) group_left(label_kubernetes_io_arch) kube_node_labels)
+                  sum by(cluster_id, namespace, label_appuio_io_node_class) (kube_pod_container_resource_requests{resource="memory"} * on(uid, cluster_id, pod, namespace) group_left kube_pod_status_phase{phase="Running"} * on(node) group_left(label_appuio_io_node_class) kube_node_labels)
                 )
                 or
                 # Select reserved memory if higher.
                 (
                   # IMPORTANT: The desired time series must always be first.
-                  sum by(cluster_id, namespace, label_kubernetes_io_arch) (kube_pod_container_resource_requests{resource="memory"} * on(uid, cluster_id, pod, namespace) group_left kube_pod_status_phase{phase="Running"} * on(node) group_left(label_kubernetes_io_arch) kube_node_labels)
+                  sum by(cluster_id, namespace, label_appuio_io_node_class) (kube_pod_container_resource_requests{resource="memory"} * on(uid, cluster_id, pod, namespace) group_left kube_pod_status_phase{phase="Running"} * on(node) group_left(label_appuio_io_node_class) kube_node_labels)
                   >
-                  sum by(cluster_id, namespace, label_kubernetes_io_arch) (container_memory_working_set_bytes{image!=""} * on(node) group_left(label_kubernetes_io_arch) kube_node_labels)
+                  sum by(cluster_id, namespace, label_appuio_io_node_class) (container_memory_working_set_bytes{image!=""} * on(node) group_left(label_appuio_io_node_class) kube_node_labels)
                 )
               )
               # Add CPU requests in violation to the ratio provided by the platform.
               + clamp_min(
                   # Convert CPU request to their memory equivalent.
-                  sum by(cluster_id, namespace, label_kubernetes_io_arch) (
-                    kube_pod_container_resource_requests{resource="cpu"} * on(uid, cluster_id, pod, namespace) group_left kube_pod_status_phase{phase="Running"} * on(node) group_left(label_kubernetes_io_arch) kube_node_labels
+                  sum by(cluster_id, namespace, label_appuio_io_node_class) (
+                    kube_pod_container_resource_requests{resource="cpu"} * on(uid, cluster_id, pod, namespace) group_left kube_pod_status_phase{phase="Running"} * on(node) group_left(label_appuio_io_node_class) kube_node_labels
                     # Build that ratio from static values
                     * on(cluster_id) group_left()(
                       # Build a time series of ratio for Cloudscale LPG 2 (4096 MiB/core)
@@ -44,7 +44,7 @@ sum_over_time(
                     )
                   )
                   # Subtract memory request
-                  - sum by(cluster_id, namespace, label_kubernetes_io_arch) (kube_pod_container_resource_requests{resource="memory"} * on(uid, cluster_id, pod, namespace) group_left kube_pod_status_phase{phase="Running"} * on(node) group_left(label_kubernetes_io_arch) kube_node_labels
+                  - sum by(cluster_id, namespace, label_appuio_io_node_class) (kube_pod_container_resource_requests{resource="memory"} * on(uid, cluster_id, pod, namespace) group_left kube_pod_status_phase{phase="Running"} * on(node) group_left(label_appuio_io_node_class) kube_node_labels
               # Only values above zero are in violation.
               ), 0)
             )
@@ -77,7 +77,7 @@ sum_over_time(
       "cluster_id",
       "tenant_id",
       "namespace",
-      "label_kubernetes_io_arch"
+      "label_appuio_io_node_class"
     )[45s:15s]
   )[59m:1m]
 )

--- a/pkg/db/seeds/appuio_cloud_memory.promql
+++ b/pkg/db/seeds/appuio_cloud_memory.promql
@@ -16,25 +16,25 @@ sum_over_time(
               (
                 # Select used memory if higher.
                 (
-                  sum by(cluster_id, namespace) (container_memory_working_set_bytes{image!=""})
+                  sum by(cluster_id, namespace, label_kubernetes_io_arch) (container_memory_working_set_bytes{image!=""} * on(node) group_left(label_kubernetes_io_arch) kube_node_labels)
                   # IMPORTANT: one clause must use equal. If used grater and lesser than, equal values will be dropped.
                   >=
-                  sum by(cluster_id, namespace) (kube_pod_container_resource_requests{resource="memory"} * on(uid, cluster_id, pod, namespace) group_left kube_pod_status_phase{phase="Running"})
+                  sum by(cluster_id, namespace, label_kubernetes_io_arch) (kube_pod_container_resource_requests{resource="memory"} * on(uid, cluster_id, pod, namespace) group_left kube_pod_status_phase{phase="Running"} * on(node) group_left(label_kubernetes_io_arch) kube_node_labels)
                 )
                 or
                 # Select reserved memory if higher.
                 (
                   # IMPORTANT: The desired time series must always be first.
-                  sum by(cluster_id, namespace) (kube_pod_container_resource_requests{resource="memory"} * on(uid, cluster_id, pod, namespace) group_left kube_pod_status_phase{phase="Running"})
+                  sum by(cluster_id, namespace, label_kubernetes_io_arch) (kube_pod_container_resource_requests{resource="memory"} * on(uid, cluster_id, pod, namespace) group_left kube_pod_status_phase{phase="Running"} * on(node) group_left(label_kubernetes_io_arch) kube_node_labels)
                   >
-                  sum by(cluster_id, namespace) (container_memory_working_set_bytes{image!=""})
+                  sum by(cluster_id, namespace, label_kubernetes_io_arch) (container_memory_working_set_bytes{image!=""} * on(node) group_left(label_kubernetes_io_arch) kube_node_labels)
                 )
               )
               # Add CPU requests in violation to the ratio provided by the platform.
               + clamp_min(
                   # Convert CPU request to their memory equivalent.
-                  sum by(cluster_id, namespace) (
-                    kube_pod_container_resource_requests{resource="cpu"} * on(uid, cluster_id, pod, namespace) group_left kube_pod_status_phase{phase="Running"}
+                  sum by(cluster_id, namespace, label_kubernetes_io_arch) (
+                    kube_pod_container_resource_requests{resource="cpu"} * on(uid, cluster_id, pod, namespace) group_left kube_pod_status_phase{phase="Running"} * on(node) group_left(label_kubernetes_io_arch) kube_node_labels
                     # Build that ratio from static values
                     * on(cluster_id) group_left()(
                       # Build a time series of ratio for Cloudscale LPG 2 (4096 MiB/core)
@@ -44,13 +44,13 @@ sum_over_time(
                     )
                   )
                   # Subtract memory request
-                  - sum by(cluster_id, namespace) (kube_pod_container_resource_requests{resource="memory"} * on(uid, cluster_id, pod, namespace) group_left kube_pod_status_phase{phase="Running"}
+                  - sum by(cluster_id, namespace, label_kubernetes_io_arch) (kube_pod_container_resource_requests{resource="memory"} * on(uid, cluster_id, pod, namespace) group_left kube_pod_status_phase{phase="Running"} * on(node) group_left(label_kubernetes_io_arch) kube_node_labels
               # Only values above zero are in violation.
               ), 0)
             )
             *
             # Join namespace label `label_appuio_io_organization` as `tenant_id`.
-            on(cluster_id, namespace)
+            on(cluster_id, namespace, label_kubernetes_io_arch)
             group_left(tenant_id)
             label_replace(
               kube_namespace_labels{label_appuio_io_organization=~".+"},
@@ -76,7 +76,8 @@ sum_over_time(
       "product",
       "cluster_id",
       "tenant_id",
-      "namespace"
+      "namespace",
+      "label_kubernetes_io_arch"
     )[45s:15s]
   )[59m:1m]
 )

--- a/pkg/db/seeds/appuio_cloud_memory.promql
+++ b/pkg/db/seeds/appuio_cloud_memory.promql
@@ -50,7 +50,7 @@ sum_over_time(
             )
             *
             # Join namespace label `label_appuio_io_organization` as `tenant_id`.
-            on(cluster_id, namespace, label_kubernetes_io_arch)
+            on(cluster_id, namespace)
             group_left(tenant_id)
             label_replace(
               kube_namespace_labels{label_appuio_io_organization=~".+"},

--- a/pkg/db/seeds/appuio_cloud_memory_sub_cpu.promql
+++ b/pkg/db/seeds/appuio_cloud_memory_sub_cpu.promql
@@ -11,9 +11,9 @@ sum_over_time(
         label_replace(
           clamp_min(
             (
-              sum by(cluster_id, namespace) (
+              sum by(cluster_id, namespace, label_kubernetes_io_arch) (
                 # Get the CPU requests
-                kube_pod_container_resource_requests{resource="cpu"} * on(uid, cluster_id, pod, namespace) group_left kube_pod_status_phase{phase="Running"}
+                kube_pod_container_resource_requests{resource="cpu"} * on(uid, cluster_id, pod, namespace) group_left kube_pod_status_phase{phase="Running"} * on(node) group_left(label_kubernetes_io_arch) kube_node_labels
                 # Convert them to their memory equivalent by multiplying them by the memory to CPU ratio
                 # Build that ratio from static values
                 * on(cluster_id) group_left()(
@@ -23,11 +23,11 @@ sum_over_time(
                   or label_replace(vector(5333057536), "cluster_id", "c-appuio-exoscale-ch-gva-2-0", "", "")
                 )
               )
-              - sum by(cluster_id, namespace) (kube_pod_container_resource_requests{resource="memory"} * on(uid, cluster_id, pod, namespace) group_left kube_pod_status_phase{phase="Running"})
+              - sum by(cluster_id, namespace, label_kubernetes_io_arch) (kube_pod_container_resource_requests{resource="memory"} * on(uid, cluster_id, pod, namespace) group_left kube_pod_status_phase{phase="Running"} * on(node) group_left(label_kubernetes_io_arch) kube_node_labels)
             )
             *
             # Join namespace label `label_appuio_io_organization` as `tenant_id`.
-            on(cluster_id, namespace)
+            on(cluster_id, namespace, label_kubernetes_io_arch)
             group_left(tenant_id)
             label_replace(
               kube_namespace_labels{label_appuio_io_organization=~".+"},
@@ -53,7 +53,8 @@ sum_over_time(
       "product",
       "cluster_id",
       "tenant_id",
-      "namespace"
+      "namespace",
+      "label_kubernetes_io_arch"
     )[45s:15s]
   )[59m:1m]
 )

--- a/pkg/db/seeds/appuio_cloud_memory_sub_cpu.promql
+++ b/pkg/db/seeds/appuio_cloud_memory_sub_cpu.promql
@@ -27,7 +27,7 @@ sum_over_time(
             )
             *
             # Join namespace label `label_appuio_io_organization` as `tenant_id`.
-            on(cluster_id, namespace, label_kubernetes_io_arch)
+            on(cluster_id, namespace)
             group_left(tenant_id)
             label_replace(
               kube_namespace_labels{label_appuio_io_organization=~".+"},

--- a/pkg/db/seeds/appuio_cloud_memory_sub_cpu.promql
+++ b/pkg/db/seeds/appuio_cloud_memory_sub_cpu.promql
@@ -11,9 +11,9 @@ sum_over_time(
         label_replace(
           clamp_min(
             (
-              sum by(cluster_id, namespace, label_kubernetes_io_arch) (
+              sum by(cluster_id, namespace, label_appuio_io_node_class) (
                 # Get the CPU requests
-                kube_pod_container_resource_requests{resource="cpu"} * on(uid, cluster_id, pod, namespace) group_left kube_pod_status_phase{phase="Running"} * on(node) group_left(label_kubernetes_io_arch) kube_node_labels
+                kube_pod_container_resource_requests{resource="cpu"} * on(uid, cluster_id, pod, namespace) group_left kube_pod_status_phase{phase="Running"} * on(node) group_left(label_appuio_io_node_class) kube_node_labels
                 # Convert them to their memory equivalent by multiplying them by the memory to CPU ratio
                 # Build that ratio from static values
                 * on(cluster_id) group_left()(
@@ -23,7 +23,7 @@ sum_over_time(
                   or label_replace(vector(5333057536), "cluster_id", "c-appuio-exoscale-ch-gva-2-0", "", "")
                 )
               )
-              - sum by(cluster_id, namespace, label_kubernetes_io_arch) (kube_pod_container_resource_requests{resource="memory"} * on(uid, cluster_id, pod, namespace) group_left kube_pod_status_phase{phase="Running"} * on(node) group_left(label_kubernetes_io_arch) kube_node_labels)
+              - sum by(cluster_id, namespace, label_appuio_io_node_class) (kube_pod_container_resource_requests{resource="memory"} * on(uid, cluster_id, pod, namespace) group_left kube_pod_status_phase{phase="Running"} * on(node) group_left(label_appuio_io_node_class) kube_node_labels)
             )
             *
             # Join namespace label `label_appuio_io_organization` as `tenant_id`.
@@ -54,7 +54,7 @@ sum_over_time(
       "cluster_id",
       "tenant_id",
       "namespace",
-      "label_kubernetes_io_arch"
+      "label_appuio_io_node_class"
     )[45s:15s]
   )[59m:1m]
 )

--- a/pkg/db/seeds/appuio_cloud_memory_sub_memory.promql
+++ b/pkg/db/seeds/appuio_cloud_memory_sub_memory.promql
@@ -21,7 +21,7 @@ sum_over_time(
           )
           *
           # Join namespace label `label_appuio_io_organization` as `tenant_id`.
-          on(cluster_id, namespace, label_kubernetes_io_arch)
+          on(cluster_id, namespace)
           group_left(tenant_id)
           label_replace(
             kube_namespace_labels{label_appuio_io_organization=~".+"},

--- a/pkg/db/seeds/appuio_cloud_memory_sub_memory.promql
+++ b/pkg/db/seeds/appuio_cloud_memory_sub_memory.promql
@@ -12,16 +12,16 @@ sum_over_time(
           clamp_min(
             (
               clamp_min(
-                sum by(cluster_id, namespace) (kube_pod_container_resource_requests{resource="memory"} * on(uid, cluster_id, pod, namespace) group_left kube_pod_status_phase{phase="Running"}),
+                sum by(cluster_id, namespace, label_kubernetes_io_arch) (kube_pod_container_resource_requests{resource="memory"} * on(uid, cluster_id, pod, namespace) group_left kube_pod_status_phase{phase="Running"} * on(node) group_left(label_kubernetes_io_arch) kube_node_labels),
                 128 * 1024 * 1024
               )
-              - sum by(cluster_id, namespace) (container_memory_working_set_bytes{image!=""})
+              - sum by(cluster_id, namespace, label_kubernetes_io_arch) (container_memory_working_set_bytes{image!=""} * on(node) group_left(label_kubernetes_io_arch) kube_node_labels)
             ),
             0
           )
           *
           # Join namespace label `label_appuio_io_organization` as `tenant_id`.
-          on(cluster_id, namespace)
+          on(cluster_id, namespace, label_kubernetes_io_arch)
           group_left(tenant_id)
           label_replace(
             kube_namespace_labels{label_appuio_io_organization=~".+"},
@@ -44,7 +44,8 @@ sum_over_time(
       "product",
       "cluster_id",
       "tenant_id",
-      "namespace"
+      "namespace",
+      "label_kubernetes_io_arch"
     )[45s:15s]
   )[59m:1m]
 )

--- a/pkg/db/seeds/appuio_cloud_memory_sub_memory.promql
+++ b/pkg/db/seeds/appuio_cloud_memory_sub_memory.promql
@@ -12,10 +12,10 @@ sum_over_time(
           clamp_min(
             (
               clamp_min(
-                sum by(cluster_id, namespace, label_kubernetes_io_arch) (kube_pod_container_resource_requests{resource="memory"} * on(uid, cluster_id, pod, namespace) group_left kube_pod_status_phase{phase="Running"} * on(node) group_left(label_kubernetes_io_arch) kube_node_labels),
+                sum by(cluster_id, namespace, label_appuio_io_node_class) (kube_pod_container_resource_requests{resource="memory"} * on(uid, cluster_id, pod, namespace) group_left kube_pod_status_phase{phase="Running"} * on(node) group_left(label_appuio_io_node_class) kube_node_labels),
                 128 * 1024 * 1024
               )
-              - sum by(cluster_id, namespace, label_kubernetes_io_arch) (container_memory_working_set_bytes{image!=""} * on(node) group_left(label_kubernetes_io_arch) kube_node_labels)
+              - sum by(cluster_id, namespace, label_appuio_io_node_class) (container_memory_working_set_bytes{image!=""} * on(node) group_left(label_appuio_io_node_class) kube_node_labels)
             ),
             0
           )
@@ -45,7 +45,7 @@ sum_over_time(
       "cluster_id",
       "tenant_id",
       "namespace",
-      "label_kubernetes_io_arch"
+      "label_appuio_io_node_class"
     )[45s:15s]
   )[59m:1m]
 )

--- a/pkg/sourcekey/sourcekey_test.go
+++ b/pkg/sourcekey/sourcekey_test.go
@@ -36,6 +36,17 @@ func TestParseWithoutClass(t *testing.T) {
 	})
 }
 
+func TestParseWithEmptyClass(t *testing.T) {
+	k, err := sourcekey.Parse("appuio_cloud_storage:c-appuio-cloudscale-lpg-2:acme-corp:sparkling-sound-1234:")
+	require.NoError(t, err)
+	require.Equal(t, k, sourcekey.SourceKey{
+		Query:     "appuio_cloud_storage",
+		Zone:      "c-appuio-cloudscale-lpg-2",
+		Tenant:    "acme-corp",
+		Namespace: "sparkling-sound-1234",
+	})
+}
+
 func TestStringWithClass(t *testing.T) {
 	key := sourcekey.SourceKey{
 		Query:     "appuio_cloud_storage",


### PR DESCRIPTION
In the end every user schedulable node should have label:

```yaml
# Exoscale
appuio.io/node-class: general-purpose
appuio.io/node-class: gpu
# Cloudscale
appuio.io/node-class: plus
appuio.io/node-class: flex
```

### Correctness

Testing with `kubernetes.io/arch` (all labels same value) and `kubernetes.io/hostname`.

### Performance

Performance takes a hit. Average query goes from ~11 seconds to ~20. Does not really matter to where the node label is moved.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
