### PR TITLE
Add billing query for VSHN PostgreSQL standalone

### DIFF
--- a/pkg/db/seeds.go
+++ b/pkg/db/seeds.go
@@ -24,6 +24,9 @@ var appuioCloudLoadbalancerQuery string
 //go:embed seeds/appuio_cloud_persistent_storage.promql
 var appuioCloudPersistentStorageQuery string
 
+//go:embed seeds/appcat_postgresql_vshn_standalone.promql
+var appcatPostgresqlVSHNStandalone string
+
 // DefaultQueries consists of default starter queries.
 var DefaultQueries = []Query{
 	{
@@ -56,6 +59,12 @@ var DefaultQueries = []Query{
 		Description: "Persistent storage usage aggregated by namespace and storageclass",
 		Query:       appuioCloudPersistentStorageQuery,
 		Unit:        "GiB",
+	},
+	{
+		Name:        "appcat_postgresql_vshn_standalone",
+		Description: "Number of VSHN managed standalone postgres instances",
+		Query:       appcatPostgresqlVSHNStandalone,
+		Unit:        "Instances",
 	},
 }
 

--- a/pkg/db/seeds/appcat_postgresql_vshn_standalone.promql
+++ b/pkg/db/seeds/appcat_postgresql_vshn_standalone.promql
@@ -1,0 +1,64 @@
+# Sum values over one hour and get mean
+sum_over_time(
+  # Udpate label product: $product:$provider:$tenant_id:$claim_namespace:$architecture
+  label_join(
+    # Add label category: $provider:$claim_namespace
+    label_join(
+      # Add label architecture: standalone-$SLA, where $SLA is the content of label appcat.vshn.io/sla
+      label_replace(
+        # Add label provider: vshn
+        label_replace(
+          # Add label product: postgres
+          label_replace(
+            # Default appcat.vshn.io/sla to besteffort if it is not set
+            label_replace(
+              # Copy label appcat.vshn.io/namespace to label claim_namespace
+              label_replace(
+                # Copy label appuio.io/organization to label tenant_id
+                label_replace(
+                  # Fetch all namespaces with label appcat.vshn.io/servicename="postgresql-standalone"
+                  kube_namespace_labels{label_appuio_io_organization=~".+", label_appcat_vshn_io_servicename="postgresql-standalone"},
+                  "tenant_id",
+                  "$1",
+                  "label_appuio_io_organization",
+                  "(.*)"
+                ),
+                "claim_namespace",
+                "$1",
+                "label_appcat_vshn_io_claim_namespace",
+                "(.*)"
+              ),
+              "label_appcat_vshn_io_sla",
+              "besteffort",
+              "label_appcat_vshn_io_sla",
+              "^$"
+            ),
+            "product",
+            "postgres",
+            "",
+            ""
+          ),
+          "provider",
+          "vshn",
+          "",
+          ""
+        ),
+        "architecture",
+        "standalone-$1",
+        "label_appcat_vshn_io_sla",
+        "(.*)"
+      ),
+      "category",
+      ":",
+      "provider",
+      "claim_namespace"
+    ),
+    "product",
+    ":",
+    "product",
+    "provider",
+    "tenant_id",
+    "claim_namespace",
+    "architecture"
+  )[59m:1m]
+)/60

--- a/pkg/db/seeds_test.go
+++ b/pkg/db/seeds_test.go
@@ -22,7 +22,7 @@ func (s *SeedsTestSuite) TestSeedDefaultQueries() {
 	_, err := d.Exec("DELETE FROM queries")
 	require.NoError(t, err)
 
-	expQueryNum := 5
+	expQueryNum := 6
 
 	count := "SELECT COUNT(*) FROM queries"
 	requireQueryEqual(t, d, 0, count)


### PR DESCRIPTION
## Summary

This PR adds a query so that we can bill VSHN managed PostgreSQL on APPUiO Cloud-


## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
