### PR TITLE
Add a command line option to set the X-Scope-OrgID header in Prometheus requests

### DIFF
--- a/pkg/thanos/thanos.go
+++ b/pkg/thanos/thanos.go
@@ -11,7 +11,7 @@ type PartialResponseRoundTripper struct {
 	Allow bool
 }
 
-// adds a new RoundTripper to the chain that sets the partial_response query parameter to the value of Allow.
+// AdditionalHeadersRoundTripper adds a new RoundTripper to the chain that sets additional static headers.
 type AdditionalHeadersRoundTripper struct {
 	http.RoundTripper
 	Headers map[string][]string

--- a/pkg/thanos/thanos.go
+++ b/pkg/thanos/thanos.go
@@ -19,9 +19,12 @@ type AdditionalHeadersRoundTripper struct {
 
 // RoundTrip implements the RoundTripper interface.
 func (t *PartialResponseRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	q := req.URL.Query()
+	r2 := new(http.Request)
+	*r2 = *req
+	q := r2.URL.Query()
 	q.Set("partial_response", strconv.FormatBool(t.Allow))
-	req.URL.RawQuery = q.Encode()
+	r2.URL.RawQuery = q.Encode()
+	req = r2
 	return t.RoundTripper.RoundTrip(req)
 }
 

--- a/pkg/thanos/thanos.go
+++ b/pkg/thanos/thanos.go
@@ -11,10 +11,34 @@ type PartialResponseRoundTripper struct {
 	Allow bool
 }
 
+// adds a new RoundTripper to the chain that sets the partial_response query parameter to the value of Allow.
+type AdditionalHeadersRoundTripper struct {
+	http.RoundTripper
+	Headers map[string][]string
+}
+
 // RoundTrip implements the RoundTripper interface.
 func (t *PartialResponseRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	q := req.URL.Query()
 	q.Set("partial_response", strconv.FormatBool(t.Allow))
 	req.URL.RawQuery = q.Encode()
 	return t.RoundTripper.RoundTrip(req)
+}
+
+// RoundTrip implements the http.RoundTripper interface.
+func (a *AdditionalHeadersRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	// The specification of http.RoundTripper says that it shouldn't mutate
+	// the request so make a copy of req.Header since this is all that is
+	// modified.
+	r2 := new(http.Request)
+	*r2 = *r
+	r2.Header = make(http.Header)
+	for k, s := range r.Header {
+		r2.Header[k] = s
+	}
+	for k, s := range a.Headers {
+		r2.Header[k] = s
+	}
+	r = r2
+	return a.RoundTripper.RoundTrip(r)
 }

--- a/tenantmapping_command.go
+++ b/tenantmapping_command.go
@@ -25,6 +25,7 @@ type tmapCommand struct {
 	AdditionalMetricSelector string
 
 	ThanosAllowPartialResponses bool
+	OrgId                       string
 }
 
 var tenantmappingCommandName = "tenantmapping"
@@ -51,6 +52,8 @@ func newTmapCommand() *cli.Command {
 				EnvVars: envVars("DRY_RUN"), Destination: &command.DryRun, Required: false, DefaultText: "false"},
 			&cli.StringFlag{Name: "additional-metric-selector", Usage: "Allows further specifying which metrics to choose. Example: --additional-metric-selector='namespace=\"testing\"'",
 				EnvVars: envVars("ADDITIONAL_METRIC_SELECTOR"), Destination: &command.AdditionalMetricSelector, Required: false, DefaultText: "false"},
+			&cli.StringFlag{Name: "org-id", Usage: "Sets the X-Scope-OrgID header to this value on requests to Prometheus", Value: "",
+				EnvVars: envVars("ORG_ID"), Destination: &command.OrgId, Required: false, DefaultText: "empty"},
 		},
 	}
 }
@@ -67,7 +70,7 @@ func (cmd *tmapCommand) execute(cliCtx *cli.Context) error {
 	// We really need to fix the inane dance around the AppLogger which needs custom plumbing and can't be used from packages because of import cycles.
 	ctx = logr.NewContext(ctx, log)
 
-	promClient, err := newPrometheusAPIClient(cmd.PrometheusURL, cmd.ThanosAllowPartialResponses)
+	promClient, err := newPrometheusAPIClient(cmd.PrometheusURL, cmd.ThanosAllowPartialResponses, cmd.OrgId)
 	if err != nil {
 		return fmt.Errorf("could not create prometheus client: %w", err)
 	}


### PR DESCRIPTION
This header is required when querying a Mimir instance. It can be set via command line or environment variable.

Currently only this specific header can be set by the user.

Relates to OCP-620

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
