### PR TITLE
Add type in products

### DIFF
--- a/pkg/db/migrations/0015_add_type_to_products.sql
+++ b/pkg/db/migrations/0015_add_type_to_products.sql
@@ -1,0 +1,5 @@
+-- The type column groups a set of targets.
+-- For instance products with target 2, 8 and 10 is of type appcat.
+
+ALTER TABLE products
+  ADD COLUMN type TEXT;

--- a/pkg/db/types.go
+++ b/pkg/db/types.go
@@ -100,6 +100,7 @@ type Product struct {
 	// See package `sourcekey` for more information.
 	Source string
 	Target sql.NullString
+	Type   sql.NullString
 	Amount float64
 	Unit   string
 
@@ -118,7 +119,7 @@ func (p Product) ForeignKeyName() string {
 func CreateProduct(p NamedPreparer, in Product) (Product, error) {
 	var product Product
 	err := GetNamed(p, &product,
-		"INSERT INTO products (source,target,amount,unit,during) VALUES (:source,:target,:amount,:unit,:during) RETURNING *", in)
+		"INSERT INTO products (source,target,type,amount,unit,during) VALUES (:source,:target,:type,:amount,:unit,:during) RETURNING *", in)
 	return product, err
 }
 

--- a/pkg/invoice/invoice_test.go
+++ b/pkg/invoice/invoice_test.go
@@ -50,14 +50,14 @@ func (s *InvoiceSuite) SetupSuite() {
 
 	require.NoError(s.T(),
 		db.GetNamed(tdb, &s.memoryProduct,
-			"INSERT INTO products (source,target,amount,unit,during) VALUES (:source,:target,:amount,:unit,:during) RETURNING *", db.Product{
+			"INSERT INTO products (source,target,type,amount,unit,during) VALUES (:source,:target,:type,:amount,:unit,:during) RETURNING *", db.Product{
 				Source: "test_memory:us-rac-2",
 				Amount: 3,
 				During: db.InfiniteRange(),
 			}))
 	require.NoError(s.T(),
 		db.GetNamed(tdb, &s.storageProduct,
-			"INSERT INTO products (source,target,amount,unit,during) VALUES (:source,:target,:amount,:unit,:during) RETURNING *", db.Product{
+			"INSERT INTO products (source,target,type,amount,unit,during) VALUES (:source,:target,:type,:amount,:unit,:during) RETURNING *", db.Product{
 				Source: "test_storage:us-rac-2",
 				Amount: 5,
 				During: db.InfiniteRange(),

--- a/pkg/report/report_test.go
+++ b/pkg/report/report_test.go
@@ -273,7 +273,7 @@ func (s *ReportSuite) createProduct(p db.NamedPreparer, source string) db.Produc
 	var product db.Product
 	require.NoError(s.T(),
 		db.GetNamed(p, &product,
-			"INSERT INTO products (source,target,amount,unit,during) VALUES (:source,:target,:amount,:unit,:during) RETURNING *", db.Product{
+			"INSERT INTO products (source,target,type,amount,unit,during) VALUES (:source,:target,:type,:amount,:unit,:during) RETURNING *", db.Product{
 				Source: source,
 				Amount: 1,
 				Unit:   "tps",


### PR DESCRIPTION
## Summary

This PR adds column `type` to the `products` table. The `type` column groups a set of targets. For instance products with target 2, 8 and 10 is of type `appcat`.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
