### PR TITLE
Fix AppCat query template to reflect reality

### DIFF
--- a/pkg/db/seeds/appcat_vshn.promql.tmpl
+++ b/pkg/db/seeds/appcat_vshn.promql.tmpl
@@ -5,7 +5,7 @@ sum_over_time(
   label_join(
     # Add label category: $provider:$claim_namespace
     label_join(
-      # Add label architecture: standalone-$SLA, where $SLA is the content of label appcat.vshn.io/sla
+      # Add label architecture: $SLA, where $SLA is the content of label appcat.vshn.io/sla
       label_replace(
         # Add label provider: vshn
         label_replace(
@@ -18,7 +18,7 @@ sum_over_time(
                 # Copy label appuio.io/organization to label tenant_id
                 label_replace(
                   # Fetch all namespaces with label appcat.vshn.io/billing-name="{{.ServiceName}}"
-                  kube_namespace_labels{label_appuio_io_organization=~".+", label_appcat_vshn_io_billing_name="{{.ServiceName}}"} * on (namespace) group_right(label_appuio_io_organization,label_appcat_vshn_io_claim_namespace,label_appcat_vshn_io_sla,product,provider,architecture, category, claim_namespace, tenant_id) kube_pod_info{created_by_kind!="Job"},
+                  kube_namespace_labels{label_appuio_io_organization=~".+", label_appuio_io_billing_name="{{.ServiceName}}"} * on (namespace) group_right(label_appuio_io_organization,label_appcat_vshn_io_claim_namespace,label_appcat_vshn_io_sla,product,provider,architecture, category, claim_namespace, tenant_id) kube_pod_info{created_by_kind!="Job"},
                   "tenant_id",
                   "$1",
                   "label_appuio_io_organization",
@@ -44,8 +44,8 @@ sum_over_time(
           "",
           ""
         ),
-        "architecture",
-        "standalone-$1",
+        "sla",
+        "$1",
         "label_appcat_vshn_io_sla",
         "(.*)"
       ),
@@ -60,6 +60,6 @@ sum_over_time(
     "provider",
     "tenant_id",
     "claim_namespace",
-    "architecture"
+    "sla"
   )[59m:1m]
 )/60 )


### PR DESCRIPTION
What's defined in the AppCat query template and what's updated in the database doesn't match.

* We actually use `appuio.io/billing-name` as the label for namespaces
* We removed the `standalone-` from the architecture and only put the SLA

## Summary

* Short summary of what's included in the PR
* Give special note to breaking changes

## Checklist

- [ ] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [ ] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
