### PR TITLE
Extract tenant ID from dedicated label instead of lookup key

### DIFF
--- a/pkg/invoice/invoice_golden_test.go
+++ b/pkg/invoice/invoice_golden_test.go
@@ -63,9 +63,9 @@ func (q fakeQuerier) Query(ctx context.Context, query string, ts time.Time, _ ..
 		}
 		res = append(res, &model.Sample{
 			Metric: map[model.LabelName]model.LabelValue{
-				"product":  model.LabelValue(k),
-				"category": model.LabelValue(fmt.Sprintf("%s:%s", sk.Zone, sk.Namespace)),
-				"tenant":   model.LabelValue(sk.Tenant),
+				"product":   model.LabelValue(k),
+				"category":  model.LabelValue(fmt.Sprintf("%s:%s", sk.Parts[1], sk.Parts[3])),
+				"tenant_id": model.LabelValue(sk.Parts[2]),
 			},
 			Value: s.Value,
 		})

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -111,6 +111,11 @@ func processSample(ctx context.Context, tx *sqlx.Tx, ts time.Time, query db.Quer
 		return err
 	}
 
+	tenantId, err := getMetricLabel(s.Metric, "tenant_id")
+	if err != nil {
+		return err
+	}
+
 	skey, err := sourcekey.Parse(string(productLabel))
 	if err != nil {
 		return fmt.Errorf("failed to parse source key from product label: %w", err)
@@ -118,10 +123,10 @@ func processSample(ctx context.Context, tx *sqlx.Tx, ts time.Time, query db.Quer
 
 	var upsertedTenant db.Tenant
 	err = upsertTenant(ctx, tx, &upsertedTenant, db.Tenant{
-		Source: skey.Tenant,
+		Source: string(tenantId),
 	}, ts)
 	if err != nil {
-		return fmt.Errorf("failed to upsert tenant '%s': %w", skey.Tenant, err)
+		return fmt.Errorf("failed to upsert tenant '%s': %w", string(tenantId), err)
 	}
 
 	var upsertedCategory db.Category

--- a/pkg/report/report_test.go
+++ b/pkg/report/report_test.go
@@ -36,7 +36,7 @@ const promTestquery = `
 			),
 			"product", "my-product:my-cluster:my-tenant:my-namespace", "", ""
 		),
-		"tenant", "my-tenant", "", ""
+		"tenant_id", "my-tenant", "", ""
 	)
 `
 const promBarTestquery = `
@@ -48,7 +48,7 @@ const promBarTestquery = `
 			),
 			"product", "bar-product:my-cluster:my-tenant:my-namespace", "", ""
 		),
-		"tenant", "my-tenant", "", ""
+		"tenant_id", "my-tenant", "", ""
 	)
 `
 

--- a/pkg/sourcekey/sourcekey.go
+++ b/pkg/sourcekey/sourcekey.go
@@ -13,13 +13,6 @@ const elementSeparator = ":"
 // SourceKey represents a source key to look up dimensions objects (currently queries and products).
 // It implements the lookup logic found in https://kb.vshn.ch/appuio-cloud/references/architecture/metering-data-flow.html#_system_idea.
 type SourceKey struct {
-	Query     string
-	Zone      string
-	Tenant    string
-	Namespace string
-
-	Class string
-
 	Parts []string
 }
 
@@ -29,13 +22,13 @@ func Parse(raw string) (SourceKey, error) {
 	if parts[len(parts)-1] == "" {
 		parts = parts[0 : len(parts)-1]
 	}
-	if len(parts) == 4 {
-		return SourceKey{parts[0], parts[1], parts[2], parts[3], "", parts}, nil
-	} else if len(parts) >= 5 {
-		return SourceKey{parts[0], parts[1], parts[2], parts[3], parts[4], parts}, nil
+
+	if len(parts) < 4 {
+		return SourceKey{}, fmt.Errorf("expected key with at least 4 elements separated by `%s` got %d", elementSeparator, len(parts))
 	}
 
-	return SourceKey{}, fmt.Errorf("expected key with at least 4 elements separated by `%s` got %d", elementSeparator, len(parts))
+	return SourceKey{parts}, nil
+
 }
 
 // String returns the string representation "query:zone:tenant:namespace:class" of the key.

--- a/pkg/sourcekey/sourcekey_test.go
+++ b/pkg/sourcekey/sourcekey_test.go
@@ -17,12 +17,7 @@ func TestParseWithClass(t *testing.T) {
 	k, err := sourcekey.Parse("appuio_cloud_storage:c-appuio-cloudscale-lpg-2:acme-corp:sparkling-sound-1234:ssd")
 	require.NoError(t, err)
 	require.Equal(t, sourcekey.SourceKey{
-		Query:     "appuio_cloud_storage",
-		Zone:      "c-appuio-cloudscale-lpg-2",
-		Tenant:    "acme-corp",
-		Namespace: "sparkling-sound-1234",
-		Class:     "ssd",
-		Parts:     []string{"appuio_cloud_storage", "c-appuio-cloudscale-lpg-2", "acme-corp", "sparkling-sound-1234", "ssd"},
+		Parts: []string{"appuio_cloud_storage", "c-appuio-cloudscale-lpg-2", "acme-corp", "sparkling-sound-1234", "ssd"},
 	}, k)
 }
 
@@ -30,11 +25,7 @@ func TestParseWithoutClass(t *testing.T) {
 	k, err := sourcekey.Parse("appuio_cloud_storage:c-appuio-cloudscale-lpg-2:acme-corp:sparkling-sound-1234")
 	require.NoError(t, err)
 	require.Equal(t, sourcekey.SourceKey{
-		Query:     "appuio_cloud_storage",
-		Zone:      "c-appuio-cloudscale-lpg-2",
-		Tenant:    "acme-corp",
-		Namespace: "sparkling-sound-1234",
-		Parts:     []string{"appuio_cloud_storage", "c-appuio-cloudscale-lpg-2", "acme-corp", "sparkling-sound-1234"},
+		Parts: []string{"appuio_cloud_storage", "c-appuio-cloudscale-lpg-2", "acme-corp", "sparkling-sound-1234"},
 	}, k)
 }
 
@@ -42,44 +33,27 @@ func TestParseWithEmptyClass(t *testing.T) {
 	k, err := sourcekey.Parse("appuio_cloud_storage:c-appuio-cloudscale-lpg-2:acme-corp:sparkling-sound-1234:")
 	require.NoError(t, err)
 	require.Equal(t, sourcekey.SourceKey{
-		Query:     "appuio_cloud_storage",
-		Zone:      "c-appuio-cloudscale-lpg-2",
-		Tenant:    "acme-corp",
-		Namespace: "sparkling-sound-1234",
-		Parts:     []string{"appuio_cloud_storage", "c-appuio-cloudscale-lpg-2", "acme-corp", "sparkling-sound-1234"},
+		Parts: []string{"appuio_cloud_storage", "c-appuio-cloudscale-lpg-2", "acme-corp", "sparkling-sound-1234"},
 	}, k)
 }
 
 func TestStringWithClass(t *testing.T) {
 	key := sourcekey.SourceKey{
-		Query:     "appuio_cloud_storage",
-		Zone:      "c-appuio-cloudscale-lpg-2",
-		Tenant:    "acme-corp",
-		Namespace: "sparkling-sound-1234",
-		Class:     "ssd",
-		Parts:     []string{"appuio_cloud_storage", "c-appuio-cloudscale-lpg-2", "acme-corp", "sparkling-sound-1234", "ssd"},
+		Parts: []string{"appuio_cloud_storage", "c-appuio-cloudscale-lpg-2", "acme-corp", "sparkling-sound-1234", "ssd"},
 	}
 	require.Equal(t, "appuio_cloud_storage:c-appuio-cloudscale-lpg-2:acme-corp:sparkling-sound-1234:ssd", key.String())
 }
 
 func TestStringWithoutClass(t *testing.T) {
 	key := sourcekey.SourceKey{
-		Query:     "appuio_cloud_storage",
-		Zone:      "c-appuio-cloudscale-lpg-2",
-		Tenant:    "acme-corp",
-		Namespace: "sparkling-sound-1234",
-		Parts:     []string{"appuio_cloud_storage", "c-appuio-cloudscale-lpg-2", "acme-corp", "sparkling-sound-1234"},
+		Parts: []string{"appuio_cloud_storage", "c-appuio-cloudscale-lpg-2", "acme-corp", "sparkling-sound-1234"},
 	}
 	require.Equal(t, "appuio_cloud_storage:c-appuio-cloudscale-lpg-2:acme-corp:sparkling-sound-1234", key.String())
 }
 
 func TestGenerateSourceKeysWithoutClass(t *testing.T) {
 	keys := sourcekey.SourceKey{
-		Query:     "appuio_cloud_storage",
-		Zone:      "c-appuio-cloudscale-lpg-2",
-		Tenant:    "acme-corp",
-		Namespace: "sparkling-sound-1234",
-		Parts:     []string{"appuio_cloud_storage", "c-appuio-cloudscale-lpg-2", "acme-corp", "sparkling-sound-1234"},
+		Parts: []string{"appuio_cloud_storage", "c-appuio-cloudscale-lpg-2", "acme-corp", "sparkling-sound-1234"},
 	}.LookupKeys()
 
 	require.Equal(t, []string{
@@ -96,12 +70,7 @@ func TestGenerateSourceKeysWithoutClass(t *testing.T) {
 
 func TestGenerateSourceKeysWithClass(t *testing.T) {
 	keys := sourcekey.SourceKey{
-		Query:     "appuio_cloud_storage",
-		Zone:      "c-appuio-cloudscale-lpg-2",
-		Tenant:    "acme-corp",
-		Namespace: "sparkling-sound-1234",
-		Class:     "ssd",
-		Parts:     []string{"appuio_cloud_storage", "c-appuio-cloudscale-lpg-2", "acme-corp", "sparkling-sound-1234", "ssd"},
+		Parts: []string{"appuio_cloud_storage", "c-appuio-cloudscale-lpg-2", "acme-corp", "sparkling-sound-1234", "ssd"},
 	}.LookupKeys()
 
 	require.Equal(t, []string{
@@ -126,12 +95,7 @@ func TestGenerateSourceKeysWithClass(t *testing.T) {
 
 func TestGenerateSourceKeysWithSixElements(t *testing.T) {
 	keys := sourcekey.SourceKey{
-		Query:     "appuio_cloud_storage",
-		Zone:      "c-appuio-cloudscale-lpg-2",
-		Tenant:    "acme-corp",
-		Namespace: "sparkling-sound-1234",
-		Class:     "ssd",
-		Parts:     []string{"appuio_cloud_storage", "c-appuio-cloudscale-lpg-2", "acme-corp", "sparkling-sound-1234", "ssd", "exoscale"},
+		Parts: []string{"appuio_cloud_storage", "c-appuio-cloudscale-lpg-2", "acme-corp", "sparkling-sound-1234", "ssd", "exoscale"},
 	}.LookupKeys()
 
 	require.Equal(t, []string{


### PR DESCRIPTION
Note: PR is based on fix/source-key-generation to avoid conflicts, will rebase onto master once that is merged

## Summary

For each query result, the corresponding tenant ID is required for the purpose of mapping to customers in the target system. Currently, that information is extracted from the source key (lookup key for products, discounts etc) - this is untidy, as in theory the lookup key could contain arbitrary values and we shouldn't rely on the tenant ID being available at a specific position therein.

To fix this, I instead extract the tenant ID from a dedicated `tenant_id` label in the query result. This seems to have been the plan from the start, looking at some of the existing code. A `tenant` label was supposed to be present in all queries, it just ended up not being used (as the source key was used instead).

I changed the label name to `tenant_id` instead of `tenant` primarily for this reason: as far as I can see, a `tenant_id` label with the correct value is already present in all the queries that are set up in appuio-cloud-reporting, appuio-managed-kubernetes-reporting, and appuio-managed-openshift-reporting. Likely, it was assumed that the label is required (since it originally should have been), and so it was included in each query. If I haven't overlooked anything, this change should therefore not break our existing setup, even though it is technically a breaking change.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
