### PR TITLE
Add queries for APPUiO Managed billing

### DIFF
--- a/pkg/db/seeds.go
+++ b/pkg/db/seeds.go
@@ -27,6 +27,9 @@ var appuioCloudPersistentStorageQuery string
 //go:embed seeds/appuio_managed_openshift_vcpu.promql
 var appuioManagedOpenShiftvCPUQuery string
 
+//go:embed seeds/appuio_managed_openshift_clusters_legacy.promql
+var appuioManagedOpenShiftClusterQuery string
+
 //go:embed seeds/appuio_managed_kubernetes_vcpu.promql
 var appuioManagedKubernetesvCPUQuery string
 
@@ -70,6 +73,12 @@ var DefaultQueries = []Query{
 		Description: "vCPU aggregated by cluster, node (app, storage), and service level",
 		Query:       appuioManagedOpenShiftvCPUQuery,
 		Unit:        "vCPU",
+	},
+	{
+		Name:        "appuio_managed_openshift_clusters",
+		Description: "Cluster base fee",
+		Query:       appuioManagedOpenShiftClusterQuery,
+		Unit:        "Clusters",
 	},
 	{
 		Name:        "appuio_managed_kubernetes_vcpu",

--- a/pkg/db/seeds/appuio_managed_openshift_clusters_legacy.promql
+++ b/pkg/db/seeds/appuio_managed_openshift_clusters_legacy.promql
@@ -1,0 +1,39 @@
+# Calculates number of clusters per cluster, but only for clusters with old billing
+# Yes, this is always 1
+# Structure of resulting product label "query:cloud:tenant:cluster:sla"
+
+# Max values over one hour.
+max_over_time(
+  # Add the final product label by joining the base product with the cluster ID, the tenant, and the service class.
+  label_join(
+    label_join(
+      label_replace(
+      # Add the base product identifier.
+        label_replace(
+            max by(cluster_id, vshn_service_level, tenant_id, cloud_provider) (
+                appuio_managed_info{vshn_service_level=~"(zero|standard|professional|premium)"}
+            ),
+            "product",
+            "appuio_managed_openshift_clusters",
+            "",
+            ".*"
+        ),
+        "class",
+        "$0",
+        "vshn_service_level",
+        "(.*)"
+      ),
+      "product",
+      ":",
+      "product",
+      "cloud_provider",
+      "tenant_id",
+      "cluster_id",
+      "class"
+    ),
+    "category",
+    ":",
+    "tenant_id",
+    "cluster_id"
+  )[58m:1m]
+)

--- a/pkg/db/seeds/appuio_managed_openshift_vcpu.promql
+++ b/pkg/db/seeds/appuio_managed_openshift_vcpu.promql
@@ -1,5 +1,5 @@
 # Calculates vCPUs for app nodes of a cluster
-# Structure of resulting product label "query:cluster:tenant::class"
+# Structure of resulting product label "query:cloud:tenant:cluster:sla:role"
 
 # Max values over one hour.
 max_over_time(
@@ -9,14 +9,15 @@ max_over_time(
       label_replace(
       # Add the base product identifier.
         label_replace(
-            sum by(cluster_id, vshn_service_level, tenant_id, role) (
-                min without(prometheus_replica) (node_cpu_info) * on (tenant_id, cluster_id, instance, vshn_service_level) group_left(role)
+            sum by(cluster_id, vshn_service_level, tenant_id, role, cloud_provider) (
+                node_cpu_info * on (tenant_id, cluster_id, instance) group_left(role)
                     label_join(
-                        (group without(prometheus_replica) (kube_node_role{role=~"app|storage"})),
+                        kube_node_role{role=~"app|storage"},
                         "instance",
                         "",
                         "node"
-                    )
+                    ) * on(cluster_id) group_left(tenant_id, vshn_service_level, cloud_provider)
+                        max by(cluster_id, tenant_id, vshn_service_level, cloud_provider)(appuio_managed_info)
             ),
             "product",
             "appuio_managed_openshift_vcpu",
@@ -31,10 +32,11 @@ max_over_time(
       "product",
       ":",
       "product",
-      "cluster_id",
+      "cloud_provider",
       "tenant_id",
-      "role", # empty namespace
-      "class"
+      "cluster_id",
+      "class",
+      "role"
     ),
     "category",
     ":",

--- a/pkg/db/seeds/promtest/appuio_managed_openshift_clusters_legacy.jsonnet
+++ b/pkg/db/seeds/promtest/appuio_managed_openshift_clusters_legacy.jsonnet
@@ -1,0 +1,44 @@
+local c = import 'common.libsonnet';
+
+local query = importstr '../appuio_managed_openshift_clusters_legacy.promql';
+
+local commonLabels = {
+  cluster_id: 'c-managed-openshift',
+};
+
+local infoLabels = commonLabels {
+  tenant_id: 't-managed-openshift',
+  vshn_service_level: 'standard',
+  cloud_provider: 'cloudscale',
+};
+
+local baseSeries = {
+  appuioInfoLabel: c.series('appuio_managed_info', infoLabels, '1x120'),
+  appuioInfoLabel2: c.series('appuio_managed_info', infoLabels {
+    vshn_service_level: 'best_effort',
+  }, '1x120'),
+};
+
+local baseCalculatedLabels = infoLabels {
+  class: super.vshn_service_level,
+  category: super.tenant_id + ':' + super.cluster_id,
+};
+
+{
+  tests: [
+    c.test(
+      'one cluster',
+      baseSeries,
+      query,
+      [
+        {
+          labels: c.formatLabels(baseCalculatedLabels {
+            product: 'appuio_managed_openshift_clusters:cloudscale:t-managed-openshift:c-managed-openshift:standard',
+          }),
+          value: 1,
+        },
+      ]
+    ),
+
+  ],
+}

--- a/pkg/db/seeds/promtest/appuio_managed_openshift_vcpu.jsonnet
+++ b/pkg/db/seeds/promtest/appuio_managed_openshift_vcpu.jsonnet
@@ -4,8 +4,12 @@ local query = importstr '../appuio_managed_openshift_vcpu.promql';
 
 local commonLabels = {
   cluster_id: 'c-managed-openshift',
+};
+
+local infoLabels = commonLabels {
   tenant_id: 't-managed-openshift',
   vshn_service_level: 'ondemand',
+  cloud_provider: 'cloudscale',
 };
 
 local baseSeries = {
@@ -32,9 +36,11 @@ local baseSeries = {
     instance: 'storage-test',
     core: '0',
   }, '1x120'),
+
+  appuioInfoLabel: c.series('appuio_managed_info', infoLabels, '1x120'),
 };
 
-local baseCalculatedLabels = commonLabels {
+local baseCalculatedLabels = infoLabels {
   class: super.vshn_service_level,
   category: super.tenant_id + ':' + super.cluster_id,
 };
@@ -49,14 +55,14 @@ local baseCalculatedLabels = commonLabels {
         {
           labels: c.formatLabels(baseCalculatedLabels {
             role: 'app',
-            product: 'appuio_managed_openshift_vcpu:c-managed-openshift:t-managed-openshift:app:ondemand',
+            product: 'appuio_managed_openshift_vcpu:cloudscale:t-managed-openshift:c-managed-openshift:ondemand:app',
           }),
           value: 2,
         },
         {
           labels: c.formatLabels(baseCalculatedLabels {
             role: 'storage',
-            product: 'appuio_managed_openshift_vcpu:c-managed-openshift:t-managed-openshift:storage:ondemand',
+            product: 'appuio_managed_openshift_vcpu:cloudscale:t-managed-openshift:c-managed-openshift:ondemand:storage',
           }),
           value: 1,
         },

--- a/pkg/db/seeds_test.go
+++ b/pkg/db/seeds_test.go
@@ -22,7 +22,7 @@ func (s *SeedsTestSuite) TestSeedDefaultQueries() {
 	_, err := d.Exec("DELETE FROM queries")
 	require.NoError(t, err)
 
-	expQueryNum := 8
+	expQueryNum := 9
 
 	count := "SELECT COUNT(*) FROM queries"
 	requireQueryEqual(t, d, 0, count)


### PR DESCRIPTION
## Summary

This adds/updates the necessary queries for APPUiO Managed OpenShift reporting.

I've realized that we can use the same vCPU query for both the new and the old billing, and distinguish between the two models based on the SLA - the old model uses a disjoint list of SLAs.

In a similar vein, the Cluster query - used for the cluster base fee from the old billing model - is set up to only return values for clusters with one of the old SLAs. In this way, new clusters won't get facts for the cluster count, and therefore won't be billed for that.

~Currently, the queries use a lookup key format of `query:cloud:sla:tenant:cluster[:role]` - this only works if we accept #147. Without #147, the tenant must be at the 3rd position in the lookup key. It could be made to work that way, it would just lead to "uglier" product keys.~

Queries use the source key format `query:cloud:tenant:cluster:sla[:role]`

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
